### PR TITLE
Add id-token write permissions to GHA

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       deployments: write
+      id-token: write
     steps:
       - uses: actions/checkout@v2
 
@@ -30,7 +31,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-region: eu-west-2
-          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK}}:role/ably-sdk-builds-features
+          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-features
           role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
 
       - uses: ably/sdk-upload-action@v1


### PR DESCRIPTION
Write permissions are needed in order to assume the aws role. See the docs https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#adding-permissions-settings