### PR TITLE
Fix `Manifest`'s `find` method

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -22,22 +22,25 @@ class Manifest {
    * Locate a node indicating compliance with a particular feature.
    *
    * @param {string[]} featurePath The feature node names, from root, forming a path to the feature.
-   * @returns {Map} The feature node.
+   * @returns {Map|undefined} The feature node, or `undefined` if a node doesn't exist.
    */
   find(featurePath) {
     let node = this.manifest.get(COMPLIANCE_KEY);
+    let notFound = false;
     featurePath.forEach((featurePathComponent) => {
       if (node) {
         node = node.get(featurePathComponent);
-        if (node !== undefined) {
-          if (node !== null && !(node instanceof Map)) {
-            throw new Error(`manifest node with key '${featurePathComponent}' should be a Map but it is of type '${typeof node}'.`);
-          }
+        if (node === undefined) {
+          notFound = true;
+        } else if (node !== null && !(node instanceof Map)) {
+          throw new Error(`manifest node with key '${featurePathComponent}' should be a Map but it is of type '${typeof node}'.`);
         }
+      } else {
+        notFound = true;
       }
     });
-    if (node === undefined) {
-      return null; // not found
+    if (notFound) {
+      return undefined; // not found
     }
     return new Properties(node);
   }

--- a/manifest.test.js
+++ b/manifest.test.js
@@ -1,0 +1,40 @@
+const { Manifest } = require('./manifest');
+
+// Wrap the provide map in a new map, under the compliance key, as required for a manifest.
+const compliance = (map) => new Map([['compliance', map]]);
+
+describe('Manifest', () => {
+  describe('find', () => {
+    const emptyMap = new Map();
+    const populatedMap = new Map([
+      ['Empty Map', emptyMap],
+    ]);
+    const complexMap = new Map([
+      ['Empty Map', emptyMap],
+      ['Populated Map', populatedMap],
+    ]);
+    const deeperMap = new Map([
+      ['Complex Map', complexMap],
+    ]);
+
+    it('succeeds in finding a populated map', () => {
+      expect((new Manifest(compliance(complexMap), complexMap)).find(['Populated Map'])).not.toBeUndefined();
+      expect((new Manifest(compliance(deeperMap), deeperMap)).find(['Complex Map', 'Populated Map'])).not.toBeUndefined();
+    });
+
+    it('succeeds in finding an empty map', () => {
+      expect((new Manifest(compliance(complexMap), complexMap)).find(['Empty Map'])).not.toBeUndefined();
+      expect((new Manifest(compliance(deeperMap), deeperMap)).find(['Complex Map', 'Empty Map'])).not.toBeUndefined();
+    });
+
+    it('returns null for a key that is not present', () => {
+      expect((new Manifest(compliance(emptyMap), populatedMap)).find(['Empty Map'])).toBeUndefined();
+      expect((new Manifest(compliance(emptyMap), emptyMap)).find(['Dummy Key'])).toBeUndefined();
+      expect((new Manifest(compliance(populatedMap), populatedMap)).find(['Dummy Key'])).toBeUndefined();
+      expect((new Manifest(compliance(complexMap), complexMap)).find(['Dummy Key'])).toBeUndefined();
+      expect((new Manifest(compliance(complexMap), complexMap)).find(['Empty Map', 'Dummy Key'])).toBeUndefined();
+      expect((new Manifest(compliance(deeperMap), deeperMap)).find(['Complex Map', 'Dummy Key'])).toBeUndefined();
+      expect((new Manifest(compliance(deeperMap), deeperMap)).find(['Complex Map', 'Empty Map', 'Dummy Key'])).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
I'm quite surprised that I hadn't spotted this oversight until now. 😳 
An object was being returned incorrectly for nodes that didn't exist in the manifest.

I've also added some testing. 🤞 

Discovered while working on the family of pull requests addressing #3.