### PR TITLE
1.2.0 Feature: Rename and expand the feature linked to `autoConnect` client options

### DIFF
--- a/sdk-manifests/ably-java.yaml
+++ b/sdk-manifests/ably-java.yaml
@@ -57,8 +57,8 @@ compliance:
       Subscribe:
         Deltas:
     Options:
-      Automatic Connection:
       Channel Retry Timeout:
+      Connection Lifecycle Control:
       Connection Recovery String:
       Host:
       Message Echoes:

--- a/sdk-manifests/ably-ruby.yaml
+++ b/sdk-manifests/ably-ruby.yaml
@@ -58,8 +58,8 @@ compliance:
       Publish:
       Subscribe:
     Options:
-      Automatic Connection:
       Channel Retry Timeout:
+      Connection Lifecycle Control:
       Connection Recovery String:
       Disconnected Retry Timeout:
       Host:

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -288,17 +288,18 @@ Realtime:
   Options:
     .synopsis: |
       `ClientOptions` that only apply to Realtime clients.
-    Automatic Connection:
-      .specification: [RTC1b, RTN3, RTL4b1, TO3e]
-      .synopsis: |
-        `autoConnect`:
-        Disable the automatic initiation of a connection when a client instance is instantiated.
     Channel Retry Timeout:
       .specification: [RTL13b, TO3l7]
       .synopsis: |
         `channelRetryTimeout`:
         Channel reattachement is attempted after this amount of time in the `SUSPENDED` connection state,
         following a server-initiated channel detach, if the connection state is `CONNECTED`.
+    Connection Lifecycle Control:
+      .specification: [RTC1b, RTN3, RTL4b1, TO3e, RTC15, RTC16, RTN11, RTN12]
+      .synopsis: |
+        `autoConnect`:
+        Disable the automatic initiation of a connection when a client instance is instantiated.
+        Implies the presence of `connect` and `close` methods on client instances, allowing the application to control when the connection process is started, as well explicitly requesting connection closure.
     Connection Recovery String:
       .specification: [RTC1c, TO3i]
       .synopsis: |

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -299,7 +299,7 @@ Realtime:
       .synopsis: |
         `autoConnect`:
         Disable the automatic initiation of a connection when a client instance is instantiated.
-        Implies the presence of `connect` and `close` methods on client instances, allowing the application to control when the connection process is started, as well explicitly requesting connection closure.
+        Requires the presence of `connect` and `close` methods on client instances, allowing the application to control when the connection process is started, as well explicitly requesting connection closure.
     Connection Recovery String:
       .specification: [RTC1c, TO3i]
       .synopsis: |


### PR DESCRIPTION
It doesn't make sense to be able to disable automatic connection but then not have access to `connect` or `close` methods on the Realtime instance or its connection instance.
Therefore, I've expanded this feature to include more specification points and have renamed it accordingly.

One of a family of pull requests addressing #3.