### PR TITLE
1.2.0 Feature: Realtime: Connection Recovery

### DIFF
--- a/sdk-manifests/ably-java.yaml
+++ b/sdk-manifests/ably-java.yaml
@@ -60,10 +60,10 @@ compliance:
       Get Identifier:
       Ping:
       Queryable State:
+      Recovery:
     Options:
       Channel Retry Timeout:
       Connection Lifecycle Control:
-      Connection Recovery String:
       Host:
       Message Echoes:
       Message Queuing:

--- a/sdk-manifests/ably-ruby.yaml
+++ b/sdk-manifests/ably-ruby.yaml
@@ -61,10 +61,10 @@ compliance:
       Get Identifier:
       Ping:
       Queryable State:
+      Recovery:
     Options:
       Channel Retry Timeout:
       Connection Lifecycle Control:
-      Connection Recovery String:
       Disconnected Retry Timeout:
       Host:
       Message Echoes:

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -296,7 +296,8 @@ Realtime:
         Mechanisms to get connection state synchronously, as well as to receive events asynchronously when connection state changes.
         Also provides access to an error reason object in case of failure.
     Recovery:
-      .specification: [RTN9, RTN10, RTN16, RTC1c, TO3i, RTN11d, RTN15a, RTN15b, RTN15d]
+      .specification:
+        [RTN9, RTN10, RTN16, RTC1c, TO3i, RTN11d, RTN15a, RTN15b, RTN15d]
       .synopsis: |
         Capability to recover a connection by explicitly providing a recovery key when instantiating a Realtime client instance,
         where that recovery key has been sourced from a previous instance.

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -297,9 +297,12 @@ Realtime:
         Capability to recover a connection by explicitly providing a recovery key when instantiating a Realtime client instance,
         where that recovery key has been sourced from a previous instance.
 
-        Client instances provide:
-        - a unique private connection `key` provided by the Ably service that is used to reconnect and retain connection state following an unexpected disconnection
+        Client instances may provide:
+        - a unique private connection `key` provided by the Ably service that can be used to publish over REST on behalf of a Realtime connection
         - a `serial` attribute, set from the `connectionSerial` received from the Ably service when `CONNECTED` state is confirmed
+          (TODO establish why this is user-facing at all)
+
+        Client instances must provide:
         - a `recoveryKey`, commposed from the connection key, latest connection serial (`connectionSerial`) and the current message serial (`msgSerial`)
     State Events:
       .specification: [RTN4, RTN25]

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -290,11 +290,6 @@ Realtime:
       .synopsis: |
         Sends a message to the Ably service and asynchronously returns the time to response, or an error if the operation failed.
         This can be useful for measuring true roundtrip client to Ably server latency for a simple message, or for checking that an underlying transport is responding currently.
-    State Events:
-      .specification: [RTN4, RTN25]
-      .synopsis: |
-        Mechanisms to get connection state synchronously, as well as to receive events asynchronously when connection state changes.
-        Also provides access to an error reason object in case of failure.
     Recovery:
       .specification:
         [RTN9, RTN10, RTN16, RTC1c, TO3i, RTN11d, RTN15a, RTN15b, RTN15d]
@@ -306,6 +301,11 @@ Realtime:
         - a unique private connection `key` provided by the Ably service that is used to reconnect and retain connection state following an unexpected disconnection
         - a `serial` attribute, set from the `connectionSerial` received from the Ably service when `CONNECTED` state is confirmed
         - a `recoveryKey`, commposed from the connection key, latest connection serial (`connectionSerial`) and the current message serial (`msgSerial`)
+    State Events:
+      .specification: [RTN4, RTN25]
+      .synopsis: |
+        Mechanisms to get connection state synchronously, as well as to receive events asynchronously when connection state changes.
+        Also provides access to an error reason object in case of failure.
   # TODO (DF1a) connectionStateTtl [ably-java]
   # TODO (DF1b) realtimeRequestTimeout [ably-java]
   # TODO asyncHttpThreadpoolSize [ably-java]

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -295,6 +295,16 @@ Realtime:
       .synopsis: |
         Mechanisms to get connection state synchronously, as well as to receive events asynchronously when connection state changes.
         Also provides access to an error reason object in case of failure.
+    Recovery:
+      .specification: [RTN9, RTN10, RTN16, RTC1c, TO3i, RTN11d, RTN15a, RTN15b, RTN15d]
+      .synopsis: |
+        Capability to recover a connection by explicitly providing a recovery key when instantiating a Realtime client instance,
+        where that recovery key has been sourced from a previous instance.
+
+        Client instances provide:
+        - a unique private connection `key` provided by the Ably service that is used to reconnect and retain connection state following an unexpected disconnection
+        - a `serial` attribute, set from the `connectionSerial` received from the Ably service when `CONNECTED` state is confirmed
+        - a `recoveryKey`, commposed from the connection key, latest connection serial (`connectionSerial`) and the current message serial (`msgSerial`)
   # TODO (DF1a) connectionStateTtl [ably-java]
   # TODO (DF1b) realtimeRequestTimeout [ably-java]
   # TODO asyncHttpThreadpoolSize [ably-java]
@@ -315,11 +325,6 @@ Realtime:
         `autoConnect`:
         Disable the automatic initiation of a connection when a client instance is instantiated.
         Implies the presence of `connect` and `close` methods on client instances, allowing the application to control when the connection process is started, as well explicitly requesting connection closure.
-    Connection Recovery String:
-      .specification: [RTC1c, TO3i]
-      .synopsis: |
-        `recover`:
-        Attempt to recover/inherit the state of a previous connection.
     Disconnected Retry Timeout:
       .specification: [TO3l1, RTN14d]
       .synopsis: |


### PR DESCRIPTION
There was no benefit in having a discrete feature node for the connection recovery string client option.
It's implicitly required for this functionality to work at all, and there's potential that client libraries could decide to offer a more idiomatic API that means it's not even framed via any client options API.

One of a family of pull requests addressing #3.