### PR TITLE
1.2.0 Feature: REST: Channel Encryption (set channel options)

### DIFF
--- a/sdk.yaml
+++ b/sdk.yaml
@@ -374,6 +374,11 @@ REST:
       .specification: RSA8e
   Channel:
     .specification: [RSN1, RTC3]
+    Encryption:
+      .specification: [RSL7, TB2b, RSN3c]
+      .synopsis: |
+        The option to configure a `cipher`, specifying encryption algorithm and attributes.
+        Used for subscribe and publish on this channel.
     Existence Check:
       .specification: [RSN2, RTS2]
       .synopsis: Discover if a channel exists with a given name.

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -379,6 +379,7 @@ REST:
       .synopsis: |
         The option to configure a `cipher`, specifying encryption algorithm and attributes.
         Used for subscribe and publish on this channel.
+        Support for `AES` with `CBC`, `PKCS#7` with a default key length of 256 bits, as well as support for `AES128`.
     Existence Check:
       .specification: [RSN2, RTS2]
       .synopsis: Discover if a channel exists with a given name.


### PR DESCRIPTION
One of a family of pull requests addressing https://github.com/ably/features/issues/3.

I could see no evidence that either the Java / Android or Ruby SDKs had methods to allow you to set options for REST channel instances.