### PR TITLE
1.2.0 Feature: Realtime: Channel State

### DIFF
--- a/sdk-manifests/ably-java.yaml
+++ b/sdk-manifests/ably-java.yaml
@@ -57,6 +57,7 @@ compliance:
         Get:
         Subscribe:
       Publish:
+      State Events:
       Subscribe:
         Deltas:
         Rewind:

--- a/sdk-manifests/ably-java.yaml
+++ b/sdk-manifests/ably-java.yaml
@@ -52,6 +52,7 @@ compliance:
     Channel:
       Attach:
       Encryption:
+      Mode:
       Presence:
         Get:
         Subscribe:

--- a/sdk-manifests/ably-ruby.yaml
+++ b/sdk-manifests/ably-ruby.yaml
@@ -57,6 +57,7 @@ compliance:
         Update:
           Client:
       Publish:
+      State Events:
       Subscribe:
         Rewind:
     Connection:

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -286,6 +286,11 @@ Realtime:
       .synopsis: |
         Send a message on this channel.
         This is a message over the Realtime connection, not a REST operation.
+    State Events:
+      .specification: [RTL2, TH1, TH2, TH3, TH4, TH5]
+      .synopsis: |
+        `ChannelEvent` events can be received asynchronously when channel state changes.
+        The current `ChannelState` can be synchronously queried (e.g. via a `state` property on the channel instance).
     Subscribe:
       .specification: [RTL7, RTL8]
       Deltas:

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -284,7 +284,7 @@ Realtime:
       Deltas:
         .documentation:
           - https://ably.com/docs/realtime/channels/channel-parameters/deltas
-        .specification: [RTL18, RTL19, RTL20, PC3, TM2i, TB2c, RTS3c]
+        .specification: [RTL16, RTL18, RTL19, RTL20, PC3, TM2i, TB2c, RTS3c]
         .synopsis: |
           Support for VCDiff-encoded delta streams.
           SDKs may choose to offer this only if a plugin is supplied via client options

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -288,7 +288,7 @@ Realtime:
         This is a message over the Realtime connection, not a REST operation.
     State Events:
       .specification:
-        [RTL2, TH1, TH2, TH3, TH4, TH5, RTN11d, RTL4e, RTL3a, RTL4g, RTL14, RTL24]
+        [RTL2, TH1, TH2, TH3, TH4, TH5, RTN11d, RTL4e, RTL3a, RTL4g, RTL14, RTL24, RTP5]
       .synopsis: |
         `ChannelEvent` events can be received asynchronously when channel state changes.
         The current `ChannelState` can be synchronously queried (e.g. via a `state` property on the channel instance).

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -287,10 +287,12 @@ Realtime:
         Send a message on this channel.
         This is a message over the Realtime connection, not a REST operation.
     State Events:
-      .specification: [RTL2, TH1, TH2, TH3, TH4, TH5]
+      .specification:
+        [RTL2, TH1, TH2, TH3, TH4, TH5, RTN11d, RTL4e, RTL3a, RTL4g, RTL14, RTL24]
       .synopsis: |
         `ChannelEvent` events can be received asynchronously when channel state changes.
         The current `ChannelState` can be synchronously queried (e.g. via a `state` property on the channel instance).
+        Also provides access to an error reason object in case of failure.
     Subscribe:
       .specification: [RTL7, RTL8]
       Deltas:

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -248,6 +248,13 @@ Realtime:
       .synopsis: |
         The option to configure a `cipher`, specifying encryption algorithm and attributes.
         Used for subscribe and publish on this channel.
+    Mode:
+      .documentation:
+        - https://faqs.ably.com/what-are-channel-mode-flags-and-how-do-i-use-them
+      .specification: [RTL16, TB2d, TR3, RTS3c]
+      .synopsis: |
+        Specify a subset of the permissions given in your token/key for use with this channel, specified using channel mode flags.
+        This feature uses Ably service-side filtering, so it can be used to save unnecessary messages counting towards your usage such as preventing presence updates going to all users.
     Presence:
       Enter:
         .specification: [RTP8, RTP10]

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -292,7 +292,7 @@ Realtime:
       .synopsis: |
         `ChannelEvent` events can be received asynchronously when channel state changes.
         The current `ChannelState` can be synchronously queried (e.g. via a `state` property on the channel instance).
-        Also provides access to an error reason object in case of failure.
+        Also provides access to an error reason object when the channel is in a state of disruption (for example `FAILED`, `DETACHED` or `SUSPENDED`).
     Subscribe:
       .specification: [RTL7, RTL8]
       Deltas:


### PR DESCRIPTION
One of a family of pull requests addressing #3.

Continues the naming style established in #21 for contexts where state has a synchronous getter as well as an asynchronous event path (e.g. `EventEmitter`).