### PR TITLE
Remove `prettier` tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "jest": "^27.5.1",
         "markdownlint-cli2": "^0.4.0",
         "npm-run-all": "^4.1.5",
-        "prettier": "2.7.1",
         "tailwindcss": "^3.0.23"
       }
     },
@@ -5598,21 +5597,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -10948,12 +10932,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
-    },
-    "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,6 @@
     "build:tailwind": "tailwindcss -i ./main.css -o ./output/tailwind.css --minify",
     "lint": "npm-run-all format:*:check",
     "format:js-code:check": "eslint --max-warnings=0 .",
-    "format:data": "prettier --write **/{*.json,*.yaml,.*.yaml}",
-    "format:data:check": "prettier --check **/{*.json,*.yaml,.*.yaml}",
     "format:documentation:check": "markdownlint-cli2 \"**/*.md\" \"#node_modules\"",
     "test": "jest"
   },
@@ -32,7 +30,6 @@
     "jest": "^27.5.1",
     "markdownlint-cli2": "^0.4.0",
     "npm-run-all": "^4.1.5",
-    "prettier": "2.7.1",
     "tailwindcss": "^3.0.23"
   }
 }


### PR DESCRIPTION
We were only using it for YAML, in fact.

Enough is enough. Fighting this tool has taken up too much time. We shall find a replacement.
see: https://github.com/ably/features/pull/35