### PR TITLE
Remove now-superfluous step leftover from `prettier` debugging

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,16 +24,9 @@ jobs:
         run: npm ci
 
       - name: Lint
-        id: lint
         run: npm run lint
 
       - name: Test and Build
         run: |
           npm test
           npm run build
-
-      - name: Debug Lint - Prettier, in particular
-        if: failure() && steps.lint.outcome == 'failure'
-        run: |
-          npm run format:data
-          git diff


### PR DESCRIPTION
I should have done this under https://github.com/ably/features/pull/36