### PR TITLE
Improve layout when both Synopsis and Docs links are available for a feature node

### DIFF
--- a/build.js
+++ b/build.js
@@ -192,12 +192,21 @@ function generateTableRows(writer, maximumLevel, parentKeys, node) {
             rowWriter.cell((cellContentWriter) => {
               let empty = true;
               if (documentationUrls) {
+                if (synopsis) {
+                  // With Synopsis and Documentation URLs we need a more complex layout
+                  cellContentWriter.write('<div class="flex flex-row">');
+                  cellContentWriter.write(`<div class="grow">${marked.parse(synopsis)}</div>`);
+                  cellContentWriter.write('<div class="grow-0">');
+                }
                 cellContentWriter.write(documentationUrls
                   .map((element) => `<a class="btn btn-blue" href="${element}" target="_blank" rel="noopener">docs</a>`)
                   .join(' '));
+                if (synopsis) {
+                  cellContentWriter.write('</div></div>');
+                }
                 empty = false;
-              }
-              if (synopsis) {
+              } else if (synopsis) {
+                // No Documentation URLs, so simply render the Synopsis.
                 cellContentWriter.write(marked.parse(synopsis));
                 empty = false;
               }

--- a/build.js
+++ b/build.js
@@ -192,18 +192,23 @@ function generateTableRows(writer, maximumLevel, parentKeys, node) {
             rowWriter.cell((cellContentWriter) => {
               let empty = true;
               if (documentationUrls) {
-                if (synopsis) {
+                const needComplexLayout = !!synopsis;
+
+                if (needComplexLayout) {
                   // With Synopsis and Documentation URLs we need a more complex layout
-                  cellContentWriter.write('<div class="flex flex-row">');
+                  cellContentWriter.write('<div class="flex flex-row">'); // this div is closed below, after writing documentation URLs
                   cellContentWriter.write(`<div class="grow">${marked.parse(synopsis)}</div>`);
-                  cellContentWriter.write('<div class="grow-0">');
+                  cellContentWriter.write('<div class="grow-0">'); // this div is closed below, after writing documentation URLs
                 }
+
                 cellContentWriter.write(documentationUrls
                   .map((element) => `<a class="btn btn-blue" href="${element}" target="_blank" rel="noopener">docs</a>`)
                   .join(' '));
-                if (synopsis) {
+
+                if (needComplexLayout) {
                   cellContentWriter.write('</div></div>');
                 }
+
                 empty = false;
               } else if (synopsis) {
                 // No Documentation URLs, so simply render the Synopsis.


### PR DESCRIPTION
This is a small thing that had been niggling me for a while. I was initially just dumping the 'docs' links above the synopsis, however that had the result of making cells taller than they really needed to be. I've now tucked them away to the right hand side of the cell.

So, where we did have this:

<img width="1401" alt="Screenshot 2022-09-15 at 09 53 07" src="https://user-images.githubusercontent.com/8318344/190361008-c0a526c0-e5e3-4b9b-9902-12fe2544ec26.png">

We now have this:

<img width="1401" alt="Screenshot 2022-09-15 at 09 53 23" src="https://user-images.githubusercontent.com/8318344/190361068-1870e3c6-61fd-4487-bda3-1159b74f4985.png">
