### PR TITLE
Refine `REST: Request Identifiers` regarding returned `ErrorInfo` API

### DIFF
--- a/build.js
+++ b/build.js
@@ -228,9 +228,9 @@ function generateTableRows(writer, maximumLevel, parentKeys, node) {
               let colourClass = 'bg-red-400';
               let svg = crossSvg;
               if (compliance) {
-                const { variants } = compliance;
+                const { caveats, variants } = compliance;
                 const hasPartialSupportForVariants = variants && manifest.isPartialVariantsCoverage(variants);
-                if (hasPartialSupportForVariants) {
+                if (hasPartialSupportForVariants || caveats) {
                   colourClass = 'bg-amber-400';
                   svg = partialSvg;
                 } else {

--- a/sdk-manifests/ably-java.yaml
+++ b/sdk-manifests/ably-java.yaml
@@ -72,6 +72,9 @@ compliance:
     Fallback Retry Timeout:
     Opaque Request:
     Request Identifiers:
+      .caveats: |
+        Returned `ErrorInfo` instances for failed requests do not include the request identifier.
+        We will fix this under https://github.com/ably/ably-java/issues/843.
     Request Timeout:
     Retry Count:
     Service:

--- a/sdk-manifests/ably-php.yaml
+++ b/sdk-manifests/ably-php.yaml
@@ -52,7 +52,6 @@ compliance:
       Release:
     Fallback Retry Timeout:
     Opaque Request:
-    Request Identifiers:
     Request Timeout:
     Retry Count:
     Retry Duration:

--- a/sdk-node-properties.js
+++ b/sdk-node-properties.js
@@ -34,6 +34,11 @@ class Properties {
       if (isPropertyKey(key)) {
         const name = propertyKeyName(key);
         switch (name) {
+          case 'caveats':
+            // used in the canonical features list
+            this.caveats = transformString(value, IDENTITY_TRANSFORM);
+            break;
+
           case 'documentation':
             // used in the canonical features list
             this.documentationUrls = transformStrings(value, (stringValue) => new URL(stringValue));

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -449,7 +449,7 @@ REST:
     .synopsis: |
       Add a query string parameter, based on a source of randomness, to all REST requests.
       Enabled using the `addRequestIds` client option.
-      For failed requests, the request identifier is included in the `ErrorInfo` returned.
+      For failed requests, the request identifier is included in the returned `ErrorInfo`.
   Request Timeout:
     .specification: TO3l4
     .synopsis: |

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -449,6 +449,7 @@ REST:
     .synopsis: |
       Add a query string parameter, based on a source of randomness, to all REST requests.
       Enabled using the `addRequestIds` client option.
+      For failed requests, the request identifier is included in the `ErrorInfo` returned.
   Request Timeout:
     .specification: TO3l4
     .synopsis: |


### PR DESCRIPTION
Partially addresses @lmars' observation around the potential oversight of `ErrorInfo`, specifically the "etc.." including request identifiers for failed requests.

see: https://github.com/ably/features/issues/3#issuecomment-1260538592