### PR TITLE
Add feature nodes for `ErrorInfo`

### DIFF
--- a/build.js
+++ b/build.js
@@ -148,6 +148,7 @@ function generateTableRows(writer, maximumLevel, parentKeys, node) {
           const {
             specificationPoints,
             documentationUrls,
+            requires,
             synopsis,
           } = new Properties(value);
 
@@ -192,13 +193,19 @@ function generateTableRows(writer, maximumLevel, parentKeys, node) {
             rowWriter.class(`px-1 ${commonCellStyle}`);
             rowWriter.cell((cellContentWriter) => {
               let empty = true;
+
+              const markdownRequires = requires ? `Requires: **${requires.join(': ')}**` : null;
+              const markdown = synopsis
+                ? `${synopsis}${markdownRequires ? `\n${markdownRequires}` : ''}`
+                : markdownRequires;
+
               if (documentationUrls) {
-                const needComplexLayout = !!synopsis;
+                const needComplexLayout = !!markdown;
 
                 if (needComplexLayout) {
                   // With Synopsis and Documentation URLs we need a more complex layout
                   cellContentWriter.write('<div class="flex flex-row">'); // this div is closed below, after writing documentation URLs
-                  cellContentWriter.write(`<div class="grow">${marked.parse(synopsis)}</div>`);
+                  cellContentWriter.write(`<div class="grow">${marked.parse(markdown)}</div>`);
                   cellContentWriter.write('<div class="grow-0">'); // this div is closed below, after writing documentation URLs
                 }
 
@@ -211,9 +218,9 @@ function generateTableRows(writer, maximumLevel, parentKeys, node) {
                 }
 
                 empty = false;
-              } else if (synopsis) {
+              } else if (markdown) {
                 // No Documentation URLs, so simply render the Synopsis.
-                cellContentWriter.write(marked.parse(synopsis));
+                cellContentWriter.write(marked.parse(markdown));
                 empty = false;
               }
               if (empty) {

--- a/sdk-manifests/ably-java.yaml
+++ b/sdk-manifests/ably-java.yaml
@@ -82,6 +82,7 @@ compliance:
       Get Time:
     Statistics:
       Query:
+    Support Hyperlink on Request Failure:
   Service:
     Environment:
     Fallback Hosts:

--- a/sdk-manifests/ably-java.yaml
+++ b/sdk-manifests/ably-java.yaml
@@ -16,6 +16,7 @@ compliance:
       URL:
         Query Time:
   Debugging:
+    Error Information:
     Logs:
   Protocol:
     JSON:

--- a/sdk-manifests/ably-php.yaml
+++ b/sdk-manifests/ably-php.yaml
@@ -12,6 +12,7 @@ compliance:
       URL:
         Query Time:
   Debugging:
+    Error Information:
     Logs:
   Protocol:
     JSON:

--- a/sdk-manifests/ably-ruby.yaml
+++ b/sdk-manifests/ably-ruby.yaml
@@ -13,6 +13,7 @@ compliance:
       URL:
         Query Time:
   Debugging:
+    Error Information:
     Logs:
   Protocol:
     JSON:

--- a/sdk-node-properties.js
+++ b/sdk-node-properties.js
@@ -44,6 +44,11 @@ class Properties {
             this.documentationUrls = transformStrings(value, (stringValue) => new URL(stringValue));
             break;
 
+          case 'requires':
+            // used in the canonical features list
+            this.requires = transformStrings(value, IDENTITY_TRANSFORM);
+            break;
+
           case 'specification':
             // used in the canonical features list
             this.specificationPoints = transformStrings(value, (stringValue) => new SpecificationPoint(stringValue));

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -450,6 +450,7 @@ REST:
       Provides a function to issue HTTP REST requests to the Ably endpoints with all the built in functionality of the library such as authentication, pagination, fallback hosts, MessagePack and JSON support etc..
       Convenience for customers who wish to use REST API functionality that is either not documented or is not included in the API for our client libraries.
   Request Identifiers:
+    .requires: [Debugging, Error Information]
     .specification: [RSC7c, TO3p]
     .synopsis: |
       Add a query string parameter, based on a source of randomness, to all REST requests.

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -70,6 +70,11 @@ Debugging:
   .synopsis: |
     Behaviours that are not necessarily suitable for production environments,
     however may need to be enabled - even when running against production environments and executing on end-customer/consumer devices - to debug issues.
+  Error Information:
+    .specification: [TI1, TI2]
+    .synopsis: |
+      Receive details of Ably service errors in Ably's conformed `ErrorInfo` structure.
+      Includes `code`, `message` and `statusCode`.
   Logs:
     .specification: [TO3b, TO3c]
     .synopsis: |

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -490,6 +490,11 @@ REST:
         Uses the `/stats` REST endpoint.
         Paginated.
         Results are provided aggregated across all channels in use in the application in the specified period and may be used to track usage against account quotas.
+  Support Hyperlink on Request Failure:
+    .requires: [Debugging, Error Information]
+    .specification: TI4
+    .synopsis: |
+      Receive `ErrorInfo` instances that include an `href` member, populated if provided by the service response, containing an Internet hyperlink for more information on the failure.
 Service:
   .synopsis: |
     Relating to how REST and Realtime client instances communicate with the Ably service,


### PR DESCRIPTION
Builds upon the work done in #61 to fully address @lmars' observations around the potential oversight of `ErrorInfo`.

see: https://github.com/ably/features/issues/3#issuecomment-1260538592