### PR TITLE
Expand on `requires` - Feature Node Dependencies

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -7,3 +7,7 @@ config:
 
   # In our GitHub First context, it's very normal to include GitHub issue URLs 'bare' so GitHub formats them nicely for us
   no-bare-urls: false
+
+  # Adds no value whatsoever to the quality of markdown we produce.
+  # In fact, mixing code block styles allows us to use the type that's best suited for the snippet being illustrated.
+  code-block-style: false

--- a/README.md
+++ b/README.md
@@ -169,6 +169,24 @@ Consistently use imperative, present tense where that makes sense (also known as
 
 As we evolve this work we can hopefully add to this guidance around what should be included and what should be avoided.
 
+## Feature Node Dependencies
+
+A feature node is able to express that it `requires` one or more features in order to be able to be implemented in an SDK.
+The following logical constraints should apply - a feature:
+
+- must only indicate it requires another feature if it cannot exist or otherwise _fully_ function without that other feature having also been implemented
+- cannot require one of its parent features, as that's implicit
+- should only require both the `REST` and `Realtime` features if both of them **must** be present in the SDK for the feature to work at all,
+  in other words:
+  - :green_circle: _needs both_: if it requires **both** `REST` **and** `Realtime` to be viable, then it should include them both in its `requires` property
+  - :red_circle: _needs one, the other, or both_: if it requires **either** `REST` **or** `Realtime` to be viable, then it must not include either of them in its `requires` property
+  - :green_circle: _needs just REST_: if it requires `REST` but does not require or otherwise relate to `Realtime`, then it should include `REST` in its `requires` property
+  - :green_circle: _needs just Realtime_: if it requires `Realtime` but does not require or otherwise relate to `REST`, then it should include `Realtime` in its `requires` property
+
+When a feature node 'A' indicates that it requires another feature 'B', then it's implied that any children of 'A' also require 'B'.
+
+We will add checks in [#64](https://github.com/ably/features/issues/64).
+
 ## Disincluded Features
 
 ### `ClientOptions#logExceptionReportingUrl`

--- a/README.md
+++ b/README.md
@@ -185,17 +185,26 @@ The following logical constraints should apply - a feature:
 
 When a feature node 'A' indicates that it requires another feature 'B', then it's implied that any children of 'A' also require 'B'.
 
-The `requires` property allows a feature to express which other feature(s) it requires using one or more pointers to feature nodes in the tree, where a `pointer` is an array of strings -- where `pointer[0]` is the name of the root node, `pointer[1]` (if present) is a child of `pointer[0]`, etc..
+The `requires` property allows a feature to express which other feature(s) it requires using one or more references to feature nodes in the tree, where a reference is a string path with node names delimited by a colon followed by a space (`': '`).
 
-To allow our YAML to be fluid and brief we allow those pointers to be supplied as a `requires` value in a number of forms:
+We have chosen to use a colon within the delimiter because it's logical in human readable form - e.g.:
 
-| Value Type | Example Value | Description | Unit Tests |
-| ---------- | ------------- | ----------- | ---------- |
-| **string**, to point to a single root node | `'Root Node'` | Shortcut form. A single string, pointing to a root node, in this example the root node with the name `'Root Node'`. |[transformPaths for string arguments](https://github.com/ably/features/blob/ae468c641cba9a41658bcd5334693d866b6e6121/transform.test.js#L87) |
-| **unwrapped array**, to point to any single node | `['Root Node', '2nd Level Node', '3rd Level Node']` | A single array, pointing to a feature node (a root node if one element, or a child if more than one element), in this example a child `'Root Node: 2nd Level Node: 3rd Level Node'`. | [transformPaths for string array arguments](https://github.com/ably/features/blob/ae468c641cba9a41658bcd5334693d866b6e6121/transform.test.js#L101) |
-| **wrapped arrays**, to point to multiple nodes | `[['Root Node A', '2nd Level Node B Child of A'], ['Root Node C', '2nd Level Node D Child of C', '3rd Level Node E Child of D'], ['Root Node F'], 'Root Node G']` | Multiple arrays, each pointing to a feature node (a root node if one element in a given array, or a child if more than one element in a given array). Also supports wrapping a mix of arrays (pointers to any node) and strings (shortcut form pointers to root nodes). In this example, four pointers: `'Root Node A: 2nd Level Node B Child of A'` and `'Root Node C: 2nd Level Node D Child of C: 3rd Level Node E Child of D'` and `'Root Node F'` and `'Root Node G'`. | [transformPaths for arrays of string arrays arguments](https://github.com/ably/features/blob/ae468c641cba9a41658bcd5334693d866b6e6121/transform.test.js#L117); transformPaths for arrays of mixed string arrays and strings arguments |
+    Service: Fallbacks: REST Follows Realtime
 
-The intention, especially with the interpretation of _unwrapped array_, is to do "do the right thing" and allow this property to be populated in the least surprising manner.
+This is intentionally the same formatting that we use in the rendered view to represent a fully-qualified feature node path.
+
+The implication of this choice of delimiter is that, in YAML, these node references - if referring to a non-root node - need to be quoted. e.g.:
+
+```yaml
+.requires:
+  - REST
+  - 'Debugging: Error Information'
+```
+
+Where:
+
+- the `REST` feature node reference did not need to be quoted, as it's a root node, therefore a path with only one segment
+- the `Debugging: Error Information` feature node reference must be quoted, as it's a child of a root node, therefore a path with more than one segment
 
 We will add checks in [#64](https://github.com/ably/features/issues/64).
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,18 @@ The following logical constraints should apply - a feature:
 
 When a feature node 'A' indicates that it requires another feature 'B', then it's implied that any children of 'A' also require 'B'.
 
+The `requires` property allows a feature to express which other feature(s) it requires using one or more pointers to feature nodes in the tree, where a `pointer` is an array of strings -- where `pointer[0]` is the name of the root node, `pointer[1]` (if present) is a child of `pointer[0]`, etc..
+
+To allow our YAML to be fluid and brief we allow those pointers to be supplied as a `requires` value in a number of forms:
+
+| Value Type | Example Value | Description | Unit Tests |
+| ---------- | ------------- | ----------- | ---------- |
+| **string**, to point to a single root node | `'Root Node'` | Shortcut form. A single string, pointing to a root node, in this example the root node with the name `'Root Node'`. |[transformPaths for string arguments](https://github.com/ably/features/blob/ae468c641cba9a41658bcd5334693d866b6e6121/transform.test.js#L87) |
+| **unwrapped array**, to point to any single node | `['Root Node', '2nd Level Node', '3rd Level Node']` | A single array, pointing to a feature node (a root node if one element, or a child if more than one element), in this example a child `'Root Node: 2nd Level Node: 3rd Level Node'`. | [transformPaths for string array arguments](https://github.com/ably/features/blob/ae468c641cba9a41658bcd5334693d866b6e6121/transform.test.js#L101) |
+| **wrapped arrays**, to point to multiple nodes | `[['Root Node A', '2nd Level Node B Child of A'], ['Root Node C', '2nd Level Node D Child of C', '3rd Level Node E Child of D'], ['Root Node F'], 'Root Node G']` | Multiple arrays, each pointing to a feature node (a root node if one element in a given array, or a child if more than one element in a given array). Also supports wrapping a mix of arrays (pointers to any node) and strings (shortcut form pointers to root nodes). In this example, four pointers: `'Root Node A: 2nd Level Node B Child of A'` and `'Root Node C: 2nd Level Node D Child of C: 3rd Level Node E Child of D'` and `'Root Node F'` and `'Root Node G'`. | [transformPaths for arrays of string arrays arguments](https://github.com/ably/features/blob/ae468c641cba9a41658bcd5334693d866b6e6121/transform.test.js#L117); transformPaths for arrays of mixed string arrays and strings arguments |
+
+The intention, especially with the interpretation of _unwrapped array_, is to do "do the right thing" and allow this property to be populated in the least surprising manner.
+
 We will add checks in [#64](https://github.com/ably/features/issues/64).
 
 ## Disincluded Features

--- a/build.js
+++ b/build.js
@@ -322,6 +322,7 @@ function validateStructure(astNode, parentKeys = []) {
 
     case 'PLAIN':
     case 'BLOCK_LITERAL':
+    case 'QUOTE_SINGLE':
       break;
 
     default:

--- a/sdk-node-properties.js
+++ b/sdk-node-properties.js
@@ -2,7 +2,7 @@ const escape = require('escape-html');
 
 const {
   IDENTITY_TRANSFORM,
-  transformPaths,
+  transformPath,
   transformString,
   transformStrings,
 } = require('./transform');
@@ -51,7 +51,7 @@ class Properties {
 
           case 'requires':
             // used in the canonical features list
-            this.requires = transformPaths(value, IDENTITY_TRANSFORM);
+            this.requires = transformStrings(value, transformPath);
             break;
 
           case 'specification':

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -106,6 +106,7 @@ Push Notifications:
       Only available on platforms that support receiving push notifications.
   Administration:
     .documentation: https://ably.com/docs/rest/push#push-admin
+    .requires: REST
     .specification: RSH1
     Channel Subscription:
       .specification: RSH1c
@@ -509,18 +510,21 @@ Service:
         When the Realtime client is connected to a fallback host endpoint, then for the duration that the transport is connected to that host,
         all HTTP REST requests are first attempted to the same datacenter that the Realtime connection is established with.
     Retry Count:
+      .requires: REST
       .specification: [TO3l5, RSC15a]
       .synopsis: |
         Override the default value of the `httpMaxRetryCount` client option,
         the maximum number of fallback hosts to use as a fallback when an HTTP request to the primary host is unreachable or indicates that it is unserviceable,
         applicable to REST operations.
     Retry Duration:
+      .requires: REST
       .specification: TO3l6
       .synopsis: |
         Override the default value of the `httpMaxRetryDuration` client option,
         the maximum elapsed time in which fallback host retries for HTTP requests will be attempted,
         applicable to REST operations.
     Retry Timeout:
+      .requires: REST
       .specification: [TO3l10, RSC15f]
       .synopsis: |
         Override the default value of the `fallbackRetryTimeout` client option, applicable to REST operations.

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -179,7 +179,7 @@ Push Notifications:
       Obtain a `LocalDevice` instance that represents the current state of the device in respect of it being a target for push notifications.
 Realtime:
   .synopsis: |
-    Additional functionality offered by Ably client instances that offer Realtime connectivity.
+    Functionality offered by Ably client instances that offer Realtime connectivity.
   Authentication:
     Get Confirmed Client Identifier:
       .specification: [RTC4, RTC17, RSA7a, RSA7b, RSA12, RSA8f, CD2a]
@@ -358,7 +358,7 @@ Realtime:
       Send opaque string key/value pairs to the service on connection using the `transportParams` client option.
 REST:
   .synopsis: |
-    Functionality offered by all Ably client instances (REST and Realtime).
+    Functionality offered by Ably client instances that offer support for REST operations.
   Authentication:
     .specification: RSC5
     Authorize:

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -445,7 +445,7 @@ REST:
       Provides a function to issue HTTP REST requests to the Ably endpoints with all the built in functionality of the library such as authentication, pagination, fallback hosts, MessagePack and JSON support etc..
       Convenience for customers who wish to use REST API functionality that is either not documented or is not included in the API for our client libraries.
   Request Identifiers:
-    .requires: [Debugging, Error Information]
+    .requires: 'Debugging: Error Information'
     .specification: [RSC7c, TO3p]
     .synopsis: |
       Add a query string parameter, based on a source of randomness, to all REST requests.
@@ -476,7 +476,7 @@ REST:
         Paginated.
         Results are provided aggregated across all channels in use in the application in the specified period and may be used to track usage against account quotas.
   Support Hyperlink on Request Failure:
-    .requires: [Debugging, Error Information]
+    .requires: 'Debugging: Error Information'
     .specification: TI4
     .synopsis: |
       Receive `ErrorInfo` instances that include an `href` member, populated if provided by the service response, containing an Internet hyperlink for more information on the failure.
@@ -485,7 +485,7 @@ Service:
     Relating to how REST and Realtime client instances communicate with the Ably service,
     in particular relating to resilience, fallbacks, etc..
   Environment:
-    .requires: [Service, Fallbacks]
+    .requires: 'Service: Fallbacks'
     .specification: [RSC11b, RSC15g, RSC15i, RTC1e, RTN17a, TO3k1]
     .synopsis: |
       Set the `environment` for REST and Realtime connections, for example to `sandbox` or a customer specific provisioning.
@@ -502,9 +502,7 @@ Service:
         Use an HTTP `GET` to `https://internet-up.ably-realtime.com/is-the-internet-up.txt` before trying the next fallback host,
         upon failure of a Realtime connection.
     REST Follows Realtime:
-      .requires:
-        - [REST]
-        - [Realtime]
+      .requires: REST, Realtime
       .specification: RTN17e
       .synopsis: |
         When the Realtime client is connected to a fallback host endpoint, then for the duration that the transport is connected to that host,

--- a/transform.js
+++ b/transform.js
@@ -18,6 +18,8 @@ const isString = (value) => value instanceof String || typeof value === 'string'
  * - string => [[string]]
  * - [string1, string2] => [[string1, string2]]
  * - [[string1], [string2, string3]] => [[string1], [string2, string3]]
+ * - [string1, [string2, string3]] => [[string1], [string2, string3]]
+ * - [string1, [string2], [string3, string4]] => [[string1], [string2], [string3, string4]]
  *
  * @param {string|string[]|string[][]} value A single string, or an array of strings, or an array of arrays of strings.
  * @param {StringTransformer} transformer A function to be called with each string.

--- a/transform.test.js
+++ b/transform.test.js
@@ -133,6 +133,30 @@ describe('transformPaths', () => {
     });
   });
 
+  describe('for arrays of mixed string arrays and strings arguments', () => {
+    it('successfully identity transforms', () => {
+      expect(transformPaths([' ', ['']], IDENTITY_TRANSFORM)).toStrictEqual([[' '], ['']]);
+
+      expect(transformPaths([['hello'], 'world', ['alphA', 'Beta']], IDENTITY_TRANSFORM))
+        .toStrictEqual([['hello'], ['world'], ['alphA', 'Beta']]);
+
+      expect(transformPaths([['a'], 'b', ['c']], IDENTITY_TRANSFORM)).toStrictEqual([['a'], ['b'], ['c']]);
+      expect(transformPaths(['a', ['b', 'c', 'd'], 'e'], IDENTITY_TRANSFORM))
+        .toStrictEqual([['a'], ['b', 'c', 'd'], ['e']]);
+    });
+
+    it('successfully custom transforms', () => {
+      expect(transformPaths([['123'], '456'], intTransformer)).toStrictEqual([[123], [456]]);
+      expect(transformPaths([['0'], '0'], intTransformer)).toStrictEqual([[0], [0]]);
+      expect(transformPaths(['-1', ['-1']], intTransformer)).toStrictEqual([[-1], [-1]]);
+      expect(transformPaths([['1'], '2', ['3']], intTransformer)).toStrictEqual([[1], [2], [3]]);
+      expect(transformPaths([['1', '2', '3'], '4', '5'], intTransformer)).toStrictEqual([[1, 2, 3], [4], [5]]);
+      expect(transformPaths([['hello'], 'world'], intTransformer)).toStrictEqual([[NaN], [NaN]]);
+      expect(transformPaths([['', '3'], '4', 'boo', ['pah']], intTransformer))
+        .toStrictEqual([[NaN, 3], [4], [NaN], [NaN]]);
+    });
+  });
+
   it('fails for non-string or non-string-array or non-string-array-array values', () => {
     expect(() => { transformPaths(0, IDENTITY_TRANSFORM); }).toThrow();
     expect(() => { transformPaths(null, IDENTITY_TRANSFORM); }).toThrow();


### PR DESCRIPTION
I've added some explanatory text around the use of the `requires` feature node property.

I've also added `REST` as a requirement to a few nodes that sit outside of the `REST` feature tree.

This thinking, plus prototyping, will help when working on https://github.com/ably/features/issues/64.