### PR TITLE
Refactor Push Notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ The names of feature nodes (those not prefixed with a dot '`.`' to denote them a
 
 - not use abbreviations
 - use plural form only if it's strictly necessary - i.e.:
-  - use plural form when the concept being captured is _always_ dealing with many things - e.g. `Options`, `Options: Agents` and `Push Notifications`
+  - use plural form when the concept being captured is _always_ dealing with many things - e.g. `Agent Identifier: Agents`, `REST: Statistics` and `Realtime: Push Notifications`
   - use plural form when the plurality is utterly baked into the naming of the primary type involved - e.g. `Options: Token Details`
-  - do not use plural form when the feature links to a primary type and includes methods or properties that involve with that type in both singular and plural contexts - e.g. `Push Notifications: Administration: Device Registration`
+  - do not use plural form when the feature links to a primary type and includes methods or properties that involve with that type in both singular and plural contexts - e.g. `REST: Push Notifications Administration: Device Registration`
 
 This is so that we keep a consistent 'tone of voice', making feature names that are easily comprehensible by human readers and sit alongside one another congruously.
 

--- a/sdk-manifests/ably-java.yaml
+++ b/sdk-manifests/ably-java.yaml
@@ -21,22 +21,6 @@ compliance:
   Protocol:
     JSON:
     MessagePack:
-  Push Notifications:
-    Activation:
-      .variants: Android
-    Administration:
-      Channel Subscription:
-        List:
-        List Channels:
-        Remove:
-        Save:
-      Device Registration:
-        Get:
-        List:
-        Remove:
-        Save:
-      Publish:
-    Local Device State:
   Realtime:
     Authentication:
     Channel:
@@ -61,6 +45,9 @@ compliance:
       State Events:
     Message Echoes:
     Message Queuing:
+    Push Notifications:
+      .variants: Android
+      Local Device State:
     Transport Parameters:
   REST:
     Authentication:
@@ -71,6 +58,18 @@ compliance:
         List Subscriptions:
         Subscribe:
     Opaque Request:
+    Push Notifications Administration:
+      Channel Subscription:
+        List:
+        List Channels:
+        Remove:
+        Save:
+      Device Registration:
+        Get:
+        List:
+        Remove:
+        Save:
+      Publish:
     Request Identifiers:
       .caveats: |
         Returned `ErrorInfo` instances for failed requests do not include the request identifier.

--- a/sdk-manifests/ably-php.yaml
+++ b/sdk-manifests/ably-php.yaml
@@ -17,19 +17,6 @@ compliance:
   Protocol:
     JSON:
     MessagePack:
-  Push Notifications:
-    Administration:
-      Channel Subscription:
-        List:
-        List Channels:
-        Remove:
-        Save:
-      Device Registration:
-        Get:
-        List:
-        Remove:
-        Save:
-      Publish:
   REST:
     Authentication:
       Authorize:
@@ -53,6 +40,18 @@ compliance:
         Subscribe:
       Release:
     Opaque Request:
+    Push Notifications Administration:
+      Channel Subscription:
+        List:
+        List Channels:
+        Remove:
+        Save:
+      Device Registration:
+        Get:
+        List:
+        Remove:
+        Save:
+      Publish:
     Request Timeout:
     Service:
       Get Time:

--- a/sdk-manifests/ably-ruby.yaml
+++ b/sdk-manifests/ably-ruby.yaml
@@ -19,19 +19,6 @@ compliance:
     JSON:
     Maximum Message Size:
     MessagePack:
-  Push Notifications:
-    Administration:
-      Channel Subscription:
-        List:
-        List Channels:
-        Remove:
-        Save:
-      Device Registration:
-        Get:
-        List:
-        Remove:
-        Save:
-      Publish:
   Realtime:
     Authentication:
     Channel:
@@ -87,6 +74,18 @@ compliance:
         Idempotence:
       Release:
     Opaque Request:
+    Push Notifications Administration:
+      Channel Subscription:
+        List:
+        List Channels:
+        Remove:
+        Save:
+      Device Registration:
+        Get:
+        List:
+        Remove:
+        Save:
+      Publish:
     Request Identifiers:
     Request Timeout:
     Service:

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -382,8 +382,13 @@ REST:
       Provides a function to issue HTTP REST requests to the Ably endpoints with all the built in functionality of the library such as authentication, pagination, fallback hosts, MessagePack and JSON support etc..
       Convenience for customers who wish to use REST API functionality that is either not documented or is not included in the API for our client libraries.
   Push Notifications Administration:
-    .documentation: https://ably.com/docs/api/rest-sdk/push-admin
+    .documentation:
+      - https://ably.com/docs/general/push/admin
+      - https://ably.com/docs/api/rest-sdk/push-admin
     .specification: RSH1
+    .synopsis: |
+      Perform management tasks relating to registering devices, managing push device subscriptions and delivering push notifications directly to devices or devices associated with a client identifier.
+      Intended to be used on a customer's servers.
     Channel Subscription:
       .specification: RSH1c
       List:

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -383,7 +383,6 @@ REST:
       Convenience for customers who wish to use REST API functionality that is either not documented or is not included in the API for our client libraries.
   Push Notifications Administration:
     .documentation: https://ably.com/docs/api/rest-sdk/push-admin
-    .requires: REST
     .specification: RSH1
     Channel Subscription:
       .specification: RSH1c

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -99,84 +99,6 @@ Protocol:
     .synopsis: |
       Encode or decode messages in binary format with [MessagePack](https://msgpack.org/).
       MessagePack, often abbreviated to MsgPack, is the default for runtime environments that have a suitable level of support for binary data.
-Push Notifications:
-  Activation:
-    .specification: [RSH2, RSH3, RSH4, RSH5, RSH6]
-    .synopsis: |
-      Only available on platforms that support receiving push notifications.
-  Administration:
-    .documentation: https://ably.com/docs/rest/push#push-admin
-    .requires: REST
-    .specification: RSH1
-    Channel Subscription:
-      .specification: RSH1c
-      List:
-        .specification: RSH1c1
-        .synopsis: |
-          List channel subscriptions.
-          Paginated.
-          Get a list of push notification subscriptions to channels,
-          using REST API `/push/channelSubscriptions` (`GET`).
-      List Channels:
-        .specification: RSH1c2
-        .synopsis: |
-          List all channels with at least one subscribed device,
-          using REST API `/push/channels` (`GET`).
-          Paginated.
-      Remove:
-        .specification: [RSH1c4, RSH1c5]
-        .synopsis: |
-          Unsubscribe from push notifications for channels.
-          Submit a request to stop receiving push notifications when push messages are published on the specified channels,
-          using REST API `/push/channelSubscriptions` (`DELETE`).
-      Save:
-        .specification: RSH1c3
-        .synopsis: |
-          Subscribe either a single device or all devices associated with a client ID to receive push notifications from messages sent to a channel,
-          using REST API `/push/channelSubscriptions` (`POST`).
-    Device Registration:
-      .specification: RSH1b
-      Get:
-        .specification: RSH1b1
-        .synopsis: |
-          Get details from a registered device.
-          Obtain the details for a device registered for receiving push registrations,
-          using REST API `/push/deviceRegistrations/<deviceId>` (`GET`).
-      List:
-        .specification: RSH1b2
-        .synopsis: |
-          List registered devices.
-          Paginated.
-          Obtain the details for devices registered for receiving push registrations,
-          using REST API `/push/deviceRegistrations` (`GET`).
-      Remove:
-        .specification: [RSH1b4, RSH1b5]
-        .synopsis: |
-          Unregister one or more devices for push notifications,
-          using REST API `/push/deviceRegistrations` (`DELETE`).
-          For a single device the REST API endpoint is suffixed `/<deviceId>` (`remove`).
-          Alternatively query parameters are used to find a device or devices
-          by `clientId` (`removeWhere`).
-      Save:
-        .specification: RSH1b3
-        .synopsis: |
-          Update a device registration, as an upsert,
-          using REST API `/push/deviceRegistrations/<deviceId>` (`PUT`).
-    Publish:
-      .documentation:
-        - https://ably.com/docs/rest/push#publish
-        - https://ably.com/docs/rest-api#push-publish
-        - https://ably.com/docs/general/push/publish#direct-publishing
-      .specification: RSH1a
-      .synopsis: |
-        Deliver a push notification to devices, addressing recipient(s):
-        - registered to Ably by device ID
-        - by their associated client ID
-        - directly using the underlying notifications service (FCM, APNs, etc.), thus bypassing registrations to Ably altogether
-  Local Device State:
-    .specification: RSH8
-    .synopsis: |
-      Obtain a `LocalDevice` instance that represents the current state of the device in respect of it being a target for push notifications.
 Realtime:
   .synopsis: |
     Functionality offered by Ably client instances that offer Realtime connectivity.
@@ -352,6 +274,20 @@ Realtime:
     .specification: [RTL6c2, RTP16, TO3g]
     .synopsis: |
       Suppress queuing of messages when connection state antipates imminent connection using the `queueMessages` client option.
+  Push Notifications:
+    .documentation: https://ably.com/docs/realtime/push
+    .specification: [RSH2, RSH3, RSH4, RSH5, RSH6]
+    .synopsis: |
+      Activate this device by registering with the platform specific push notification service (APNs on iOS, FCM on Android).
+      Only available on platforms that support receiving push notifications using
+      [Apple's Push Notification](https://developer.apple.com/notifications/) service
+      or
+      [Google's Firebase Cloud Messaging](https://firebase.google.com/docs/cloud-messaging/) service
+      as supported by the runtime platform.
+    Local Device State:
+      .specification: RSH8
+      .synopsis: |
+        Obtain a `LocalDevice` instance that represents the current state of the device in respect of it being a target for push notifications.
   Transport Parameters:
     .specification: RTC1f
     .synopsis: |
@@ -420,6 +356,7 @@ REST:
           Make REST publish operations idempotent.
           Enabled by default or can be disabled by setting the `idempotentRestPublishing` client option to `false`.
     Push Notifications:
+      .requires: 'Realtime: Push Notifications'
       .specification: RSH7
       .synopsis: |
         Available on platforms that support receiving push notifications.
@@ -444,6 +381,75 @@ REST:
     .synopsis: |
       Provides a function to issue HTTP REST requests to the Ably endpoints with all the built in functionality of the library such as authentication, pagination, fallback hosts, MessagePack and JSON support etc..
       Convenience for customers who wish to use REST API functionality that is either not documented or is not included in the API for our client libraries.
+  Push Notifications Administration:
+    .documentation: https://ably.com/docs/api/rest-sdk/push-admin
+    .requires: REST
+    .specification: RSH1
+    Channel Subscription:
+      .specification: RSH1c
+      List:
+        .specification: RSH1c1
+        .synopsis: |
+          List channel subscriptions.
+          Paginated.
+          Get a list of push notification subscriptions to channels,
+          using REST API `/push/channelSubscriptions` (`GET`).
+      List Channels:
+        .specification: RSH1c2
+        .synopsis: |
+          List all channels with at least one subscribed device,
+          using REST API `/push/channels` (`GET`).
+          Paginated.
+      Remove:
+        .specification: [RSH1c4, RSH1c5]
+        .synopsis: |
+          Unsubscribe from push notifications for channels.
+          Submit a request to stop receiving push notifications when push messages are published on the specified channels,
+          using REST API `/push/channelSubscriptions` (`DELETE`).
+      Save:
+        .specification: RSH1c3
+        .synopsis: |
+          Subscribe either a single device or all devices associated with a client ID to receive push notifications from messages sent to a channel,
+          using REST API `/push/channelSubscriptions` (`POST`).
+    Device Registration:
+      .specification: RSH1b
+      Get:
+        .specification: RSH1b1
+        .synopsis: |
+          Get details from a registered device.
+          Obtain the details for a device registered for receiving push registrations,
+          using REST API `/push/deviceRegistrations/<deviceId>` (`GET`).
+      List:
+        .specification: RSH1b2
+        .synopsis: |
+          List registered devices.
+          Paginated.
+          Obtain the details for devices registered for receiving push registrations,
+          using REST API `/push/deviceRegistrations` (`GET`).
+      Remove:
+        .specification: [RSH1b4, RSH1b5]
+        .synopsis: |
+          Unregister one or more devices for push notifications,
+          using REST API `/push/deviceRegistrations` (`DELETE`).
+          For a single device the REST API endpoint is suffixed `/<deviceId>` (`remove`).
+          Alternatively query parameters are used to find a device or devices
+          by `clientId` (`removeWhere`).
+      Save:
+        .specification: RSH1b3
+        .synopsis: |
+          Update a device registration, as an upsert,
+          using REST API `/push/deviceRegistrations/<deviceId>` (`PUT`).
+    Publish:
+      .documentation:
+        - https://ably.com/docs/rest/push#publish
+        - https://ably.com/docs/rest-api#push-publish
+        - https://ably.com/docs/general/push/publish#direct-publishing
+      .specification: RSH1a
+      .synopsis: |
+        Deliver a push notification to devices, addressing recipient(s):
+        - registered to Ably by device ID
+        - by their associated client ID
+        - directly using the underlying notifications service (FCM, APNs, etc.), thus bypassing registrations to Ably altogether
   Request Identifiers:
     .requires: 'Debugging: Error Information'
     .specification: [RSC7c, TO3p]


### PR DESCRIPTION
Addresses an observation made by @owenpearson when we had an informal knowledge sharing call discussing the work taking place in this repository.

It seemed logical to me to have a 'Push Notifications' root node when I created it, however there is a clear split between 'Realtime' and 'REST' subordinate features, so I delete that root node in this pull request and move its children to locations appropriate to their operational scope.

See: [05/10/22 SDK Biweekly Sync - Canonical Features](https://ably.atlassian.net/wiki/spaces/SDK/pages/2338226184/05+10+22+SDK+Biweekly+Sync+-+Canonical+Features) (internal)