### PR TITLE
Redirect feature spec point references from `docs.ably.com` to `sdk.ably.com`

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ We will add checks in [#64](https://github.com/ably/features/issues/64).
 
 ### `ClientOptions#logExceptionReportingUrl`
 
-Specified by [TO3m](https://docs.ably.com/client-lib-development-guide/features/#TO3m)
-and [RSC20](https://docs.ably.com/client-lib-development-guide/features/#RSC20).
+Specified by [TO3m](https://sdk.ably.com/builds/ably/specification/main/features/#TO3m)
+and [RSC20](https://sdk.ably.com/builds/ably/specification/main/features/#RSC20).
 
 Will be removed under [ably/docs#1381](https://github.com/ably/docs/issues/1381).

--- a/sdk-manifests/ably-ruby.yaml
+++ b/sdk-manifests/ably-ruby.yaml
@@ -26,8 +26,8 @@ compliance:
 
       # setOptions on existing channel instance is missing (i.e. it works but is inelegant, requiring soft-deprecated mechanism)
       # see:
-      # - https://docs.ably.com/client-lib-development-guide/features/#RSN3c
-      # - https://docs.ably.com/client-lib-development-guide/features/#RTS3c
+      # - https://sdk.ably.com/builds/ably/specification/main/features/#RSN3c
+      # - https://sdk.ably.com/builds/ably/specification/main/features/#RTS3c
       Encryption:
 
       History:

--- a/sdk-node-properties.js
+++ b/sdk-node-properties.js
@@ -25,7 +25,7 @@ class SpecificationPoint {
   }
 
   toHtmlLink() {
-    const url = `https://docs.ably.com/client-lib-development-guide/features/#${this.value}`;
+    const url = `https://sdk.ably.com/builds/ably/specification/main/features/#${this.value}`;
     return `<a href="${url}" target="_blank" rel="noopener"><code>${escape(this.value)}</code></a>`;
   }
 }

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -113,7 +113,7 @@ Realtime:
       .synopsis: |
         Explicit, discrete methods to attach and detach channels.
         Not all applications need this, due to our implicit-attach-on-subscribe behaviour
-        ([`RTL7c`](https://docs.ably.com/client-lib-development-guide/features/#RTL7c)).
+        ([`RTL7c`](https://sdk.ably.com/builds/ably/specification/main/features/#RTL7c)).
     Encryption:
       .specification: [RTL16, TB2b, RTS3c]
       .synopsis: |


### PR DESCRIPTION
Now that the features spec [has moved](https://github.com/ably/specification/issues/1) from [the `ably/docs` repository](https://github.com/ably/docs) to its new home in [the `ably/specification` repository](https://github.com/ably/specification), it's also published to a different location.