### PR TITLE
Expand `Channel: Publish` feature nodes for `REST` and `Realtime`

### DIFF
--- a/sdk.yaml
+++ b/sdk.yaml
@@ -176,9 +176,12 @@ Realtime:
             Update presence data and/or extras for a `clientId`,
             not necessarily the id for this client.
     Publish:
-      .specification: RTL6
+      .specification: [RTL6, TM1, TM2, TM4]
       .synopsis: |
-        Send a message on this channel.
+        Send a message on this channel, using one of the following forms:
+        - a single `Message` instance
+        - an array of `Message` instances
+        - as discrete `name` and `data` payload message components, used to publish a single `Message`
     Retry Timeout:
       .specification: [RTL13b, TO3l7]
       .synopsis: |
@@ -345,9 +348,12 @@ REST:
         .synopsis: |
           Paginated.
     Publish:
-      .specification: RSL1
+      .specification: [RSL1, TM1, TM2, TM4]
       .synopsis: |
-        Send a message on this channel.
+        Send a message on this channel, using one of the following forms:
+        - a single `Message` instance
+        - an array of `Message` instances
+        - as discrete `name` and `data` payload message components, used to publish a single `Message`
       Idempotence:
         .documentation:
           - https://ably.com/blog/introducing-idempotent-publishing


### PR DESCRIPTION
Addresses @lmars' observation around the potential oversight of "Publish message with name", as well as "Publish multiple messages".

see: https://github.com/ably/features/issues/3#issuecomment-1260538592

Having discussed this with @owenpearson, @Peter-Maguire and @stmoreau earlier today - we agreed that it would be incomplete for an SDK to implement publish for either REST or Realtime without offering all of the overloads we advertise under [RSL1a](https://sdk.ably.com/builds/ably/specification/main/features/#RSL1a).

## Also, related, but not in this PR...

I queried the purpose of [RSL1l](https://sdk.ably.com/builds/ably/specification/main/features/#RSL1l) (see [this internal Slack thread](https://ably-real-time.slack.com/archives/C030C5YLY/p1665494612333419)) which has resulted in https://github.com/ably/features/pull/73, that adds a new feature node for that overload (REST only).

I am yet to explore whether we need one or more feature nodes adding in response to observations that we may be missing "Publish message with headers in extras" and "Publish message with references in extras", which feel related.
