### PR TITLE
Add `Parameters for Query String` (`RSL1l`) to `REST: Channel: Publish` feature

### DIFF
--- a/build.js
+++ b/build.js
@@ -398,6 +398,7 @@ function titleForLink(url) {
     ['ably.com/blog', 'blog'],
     ['ably.com/docs', 'docs'],
     ['faqs.ably.com', 'faq'],
+    ['github.com/ably/.*/issues', 'issue'],
   ];
 
   const foundPair = titlesForPrefixes.find((element) => (new RegExp(`https://${element[0]}/`)).test(url));

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -361,6 +361,15 @@ REST:
         .synopsis: |
           Make REST publish operations idempotent.
           Enabled by default or can be disabled by setting the `idempotentRestPublishing` client option to `false`.
+      Parameters for Query String:
+        .documentation:
+          - https://github.com/ably/docs/issues/737
+          - https://github.com/ably/docs/issues/1017
+          - https://faqs.ably.com/why-are-some-rest-publishes-on-a-channel-slow-and-then-typically-faster-on-subsequent-publishes
+        .specification: RSL1l
+        .synopsis: |
+          Supply parameters to be encoded using normal querystring-encoding and then sent as part of the HTTP request query string for individual REST publish operations.
+          Used to change Ably service behaviour, for example setting the boolean `quickAck` option to `true`.
     Push Notifications:
       .requires: 'Realtime: Push Notifications'
       .specification: RSH7


### PR DESCRIPTION
An oversight I spotted when exploring `RSL1`, in response to https://github.com/ably/features/issues/3#issuecomment-1260538592.

As I understand, from [this Slack thread (internal)](https://ably-real-time.slack.com/archives/C030C5YLY/p1665494612333419), this feature is probably only offered by [our `ably-js` SDK](https://github.com/ably/ably-js) and _might_ be offered by [our `ably-ruby` SDK](https://github.com/ably/ably-ruby) but in a different way.

We can add compliance to manifests at a later date. For now, I was just keen to get this feature surfaced and explained.