### PR TITLE
Add feature nodes for Channel Status REST APIs

### DIFF
--- a/sdk-manifests/ably-php.yaml
+++ b/sdk-manifests/ably-php.yaml
@@ -39,6 +39,8 @@ compliance:
         List Subscriptions:
         Subscribe:
       Release:
+      Status:
+        Channel Details: # https://github.com/ably/ably-php/pull/159
     Opaque Request:
     Push Notifications Administration:
       Channel Subscription:

--- a/sdk-manifests/ably-ruby.yaml
+++ b/sdk-manifests/ably-ruby.yaml
@@ -73,6 +73,8 @@ compliance:
       Publish:
         Idempotence:
       Release:
+      Status:
+        Channel Details: # https://github.com/ably/ably-ruby/pull/365
     Opaque Request:
     Push Notifications Administration:
       Channel Subscription:

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -391,6 +391,26 @@ REST:
     Release:
       .specification: [RSN4, RTS4]
       .synopsis: Free up resources consumed by a local channel instance.
+    Status:
+      .documentation: https://ably.com/docs/rest/channel-status
+      .synopsis: |
+        Access information about channels from the Ably service.
+      Channel Details:
+        .documentation: https://ably.com/docs/rest/channel-status#metadata-rest
+        .specification: RSL8
+        .synopsis: |
+          Retrieve channel metadata from the Ably service, presented as a `ChannelDetails` instance, including global occupancy.
+          This feature is also known as channel lifecycle status.
+      Enumerate:
+        .documentation: https://ably.com/docs/rest/channel-status#enumeration-rest
+        .synopsis: |
+          Retrieve information on all active channels in this Ably application,
+          using REST API `/channels`.
+          Paginated.
+
+          Support for:
+          - querying only those channels whose name starts with a given `prefix`
+          - choosing return type as either `ChannelDetails` instances (the default) or just channel names
   Opaque Request:
     .specification: [RSC19, RTC9]
     .synopsis: |


### PR DESCRIPTION
Addresses @lmars' observation around the potential oversight of "Channel status".

see: https://github.com/ably/features/issues/3#issuecomment-1260538592

Of these two features:

- `Channel Details`: has been specified and implemented in some SDKs (those that tend to be used server-side)
- `Enumerate`: has not yet been specified, nor implemented in any SDKs