### PR TITLE
Add feature node for `Incremental Backoff` to `Realtime: Connection` (`RTB1`)

### DIFF
--- a/sdk.yaml
+++ b/sdk.yaml
@@ -234,7 +234,7 @@ Realtime:
       .synopsis: |
         Use backoff and jitter coefficients to make the constant `disconnectedRetryTimeout` and `channelRetryTimeout` values variable at runtime.
         This eases pressure on the Ably service when many client instances get disconnected at the same time,
-        because they'll not all attempt to retry connecting at the same time as one another.
+        since they won't all attempt to re-establish connection at the same time as one another.
     Lifecycle Control:
       .specification: [RTC1b, RTN3, RTL4b1, TO3e, RTC15, RTC16, RTN11, RTN12]
       .synopsis: |

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -229,6 +229,12 @@ Realtime:
       .synopsis: |
         Get the `id` of the connection, which is a public string provided by the Ably service and is unique for this connection.
         Unavailable until connected.
+    Incremental Backoff:
+      .specification: RTB1
+      .synopsis: |
+        Use backoff and jitter coefficients to make the constant `disconnectedRetryTimeout` and `channelRetryTimeout` values variable at runtime.
+        This eases pressure on the Ably service when many client instances get disconnected at the same time,
+        because they'll not all attempt to retry connecting at the same time as one another.
     Lifecycle Control:
       .specification: [RTC1b, RTN3, RTL4b1, TO3e, RTC15, RTC16, RTN11, RTN12]
       .synopsis: |

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -232,7 +232,7 @@ Realtime:
     Incremental Backoff:
       .specification: RTB1
       .synopsis: |
-        Use backoff and jitter coefficients to make the constant `disconnectedRetryTimeout` and `channelRetryTimeout` values variable at runtime.
+        Use backoff and jitter coefficients to vary the `disconnectedRetryTimeout` and `channelRetryTimeout` values at runtime.
         This eases pressure on the Ably service when many client instances get disconnected at the same time,
         since they won't all attempt to re-establish connection at the same time as one another.
     Lifecycle Control:


### PR DESCRIPTION
Addresses @lmars' observation around the potential oversight of "Incremental backoff".

see: https://github.com/ably/features/issues/3#issuecomment-1260538592

At the time of writing this opening comment none of the SDKs for which we have manifests in this repository at the moment have implemented this feature, however it is:

- done for JS: https://github.com/ably/ably-js/pull/1008
- WIP for .NET: https://github.com/ably/ably-dotnet/pull/1176