### PR TITLE
Enhance `Attach` and `Subscribe` feature nodes within `Realtime: Channel`

### DIFF
--- a/main.css
+++ b/main.css
@@ -7,7 +7,10 @@
     @apply text-2xl font-bold;
   }
   ul {
-    @apply list-disc pl-5;
+    @apply list-disc pl-5 mb-2;
+  }
+  p {
+    @apply mb-2;
   }
   code {
     @apply text-slate-600 bg-amber-100;

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -109,6 +109,10 @@ Realtime:
         Get the `clientId` confirmed with the Ably service for this client instance, once a connection has been established.
   Channel:
     Attach:
+      .documentation:
+        - https://ably.com/docs/realtime/channels#channel-lifecycle
+        - https://ably.com/docs/realtime/channels#channel-detach
+        - https://faqs.ably.com/does-an-attached-channel-receive-messages-even-if-subscribe-has-not-been-called
       .specification: [RTL4, RTL5]
       .synopsis: |
         Explicit, discrete methods to attach and detach channels.
@@ -196,9 +200,16 @@ Realtime:
         The current `ChannelState` can be queried (e.g. via a `state` property on the channel instance).
         Also, access to an error reason object when the channel is in a state of disruption (for example `FAILED`, `DETACHED` or `SUSPENDED`).
     Subscribe:
+      .documentation:
+        - https://ably.com/docs/realtime/channels#subscribing
+        - https://ably.com/docs/realtime/channels#implicit-attach
       .specification: [RTL7, RTL8, TM1, TM2, TM4]
       .synopsis: |
-        Subscribe or unsubscribe for messages on channels for this client.
+        Subscribe or unsubscribe for messages on channels for this client, using one of the following forms:
+        - all messages
+        - only messages with a specific value in their `name` member
+
+        The SDK will send a request to the Ably service to attach the channel if it is not already attached.
       Deltas:
         .documentation:
           - https://ably.com/docs/realtime/channels/channel-parameters/deltas


### PR DESCRIPTION
Addresses @lmars observation around the potential oversight of "Subscribe to messages by name", aligning with the synopsis changes made in #72.

Also, some other related embellishments.

see: https://github.com/ably/features/issues/3#issuecomment-1260538592