### PR TITLE
Added missing agents feature to dotnet

### DIFF
--- a/sdk-manifests/ably-dotnet.yaml
+++ b/sdk-manifests/ably-dotnet.yaml
@@ -2,6 +2,9 @@
 ---
 common-version: 1.2.0-alpha.1
 compliance:
+  Agent Identifier:
+    Agents:
+    Runtime:
   Authentication:
     API Key:
     Token:

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -18,7 +18,7 @@ Agent Identifier:
     .synopsis: |
       Include a product component indicating the type of runtime, as discrete from the OS type.
       This does not always include a version (e.g. for `browser` runtime emitted by `ably-js`
-      and the `uwp` runtime emitted by `ably-dotnet`).
+      and `xamarin-android`/`xamarin-iOS` runtime emitted by `ably-dotnet`).
 Authentication:
   .documentation:
     - https://ably.com/docs/core-features/authentication


### PR DESCRIPTION
- Depends on https://github.com/ably/ably-dotnet/pull/1195
- Added agents and runtime under Agent Identifier
- Removed deprecated `uwp` runtime comment as per https://github.com/ably/ably-dotnet/pull/1101