### PR TITLE
Marker nodes

### DIFF
--- a/build.js
+++ b/build.js
@@ -160,13 +160,13 @@ function generateTableRows(writer, maximumLevel, parentKeys, node) {
             documentationUrls,
             requires,
             synopsis,
-            isMarker,
+            isHeading,
           } = new Properties(value);
 
           console.log(`${consoleIndent}${key}:`);
           const verticalBordersStyle = 'border-slate-300 border-b-2';
           const commonCellStyle = `${verticalBordersStyle} border-r-2`;
-          writer.class(`align-middle tooltip-container${isMarker ? ' bg-slate-200' : ''}`);
+          writer.class(`align-middle tooltip-container${isHeading ? ' bg-slate-200' : ''}`);
           writer.row((rowWriter) => {
             // Indent using empty cells
             for (let i = 1; i <= level; i += 1) {
@@ -181,7 +181,7 @@ function generateTableRows(writer, maximumLevel, parentKeys, node) {
             if (cellCount > 1) {
               rowWriter.columnSpan(cellCount);
             }
-            rowWriter.class(`pr-3 whitespace-nowrap ${commonCellStyle} ${isMarker ? 'font-bold' : ''}`);
+            rowWriter.class(`pr-3 whitespace-nowrap ${commonCellStyle} ${isHeading ? 'font-bold' : ''}`);
             rowWriter.cell((cellContentWriter) => {
               if (level > 0) {
                 const tip = `<strong>${escape(parentKeys.join(': '))}</strong>: ${escape(key)}`;
@@ -260,10 +260,10 @@ function generateTableRows(writer, maximumLevel, parentKeys, node) {
                 }
               }
 
-              rowWriter.class(`px-1 ${isMarker ? '' : colourClass} ${commonCellStyle}`);
+              rowWriter.class(`px-1 ${isHeading ? '' : colourClass} ${commonCellStyle}`);
               rowWriter.cell((cellContentWriter) => {
                 cellContentWriter.write('<div class="flex justify-center">');
-                cellContentWriter.write(isMarker ? '&nbsp;' : svg);
+                cellContentWriter.write(isHeading ? '&nbsp;' : svg);
                 cellContentWriter.write('</div>');
               });
             });

--- a/build.js
+++ b/build.js
@@ -160,12 +160,13 @@ function generateTableRows(writer, maximumLevel, parentKeys, node) {
             documentationUrls,
             requires,
             synopsis,
+            isMarker,
           } = new Properties(value);
 
           console.log(`${consoleIndent}${key}:`);
           const verticalBordersStyle = 'border-slate-300 border-b-2';
           const commonCellStyle = `${verticalBordersStyle} border-r-2`;
-          writer.class('align-middle tooltip-container');
+          writer.class(`align-middle tooltip-container${isMarker ? ' bg-slate-200' : ''}`);
           writer.row((rowWriter) => {
             // Indent using empty cells
             for (let i = 1; i <= level; i += 1) {
@@ -180,7 +181,7 @@ function generateTableRows(writer, maximumLevel, parentKeys, node) {
             if (cellCount > 1) {
               rowWriter.columnSpan(cellCount);
             }
-            rowWriter.class(`pr-3 whitespace-nowrap ${commonCellStyle}`);
+            rowWriter.class(`pr-3 whitespace-nowrap ${commonCellStyle} ${isMarker ? 'font-bold' : ''}`);
             rowWriter.cell((cellContentWriter) => {
               if (level > 0) {
                 const tip = `<strong>${escape(parentKeys.join(': '))}</strong>: ${escape(key)}`;
@@ -259,10 +260,10 @@ function generateTableRows(writer, maximumLevel, parentKeys, node) {
                 }
               }
 
-              rowWriter.class(`px-1 ${colourClass} ${commonCellStyle}`);
+              rowWriter.class(`px-1 ${isMarker ? '' : colourClass} ${commonCellStyle}`);
               rowWriter.cell((cellContentWriter) => {
                 cellContentWriter.write('<div class="flex justify-center">');
-                cellContentWriter.write(svg);
+                cellContentWriter.write(isMarker ? '&nbsp;' : svg);
                 cellContentWriter.write('</div>');
               });
             });

--- a/sdk-node-properties.js
+++ b/sdk-node-properties.js
@@ -44,6 +44,14 @@ class Properties {
             this.caveats = transformString(value, IDENTITY_TRANSFORM);
             break;
 
+          case 'class':
+            // used in the canonical features list
+            if (transformString(value, IDENTITY_TRANSFORM) !== 'Marker') {
+              throw new Error("Class value is not recognised, expected 'Marker'.");
+            }
+            this.isMarker = true;
+            break;
+
           case 'documentation':
             // used in the canonical features list
             this.documentationUrls = transformStrings(value, (stringValue) => new URL(stringValue));

--- a/sdk-node-properties.js
+++ b/sdk-node-properties.js
@@ -46,10 +46,10 @@ class Properties {
 
           case 'class':
             // used in the canonical features list
-            if (transformString(value, IDENTITY_TRANSFORM) !== 'Marker') {
-              throw new Error("Class value is not recognised, expected 'Marker'.");
+            if (transformString(value, IDENTITY_TRANSFORM) !== 'Heading') {
+              throw new Error("Class value is not recognised, expected 'Heading'.");
             }
-            this.isMarker = true;
+            this.isHeading = true;
             break;
 
           case 'documentation':

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -20,6 +20,7 @@ Agent Identifier:
       This does not always include a version (e.g. for `browser` runtime emitted by `ably-js`
       and `xamarin-android`/`xamarin-iOS` runtime emitted by `ably-dotnet`).
 Authentication:
+  .class: Marker
   .documentation:
     - https://ably.com/docs/core-features/authentication
   .specification: [AO1, AO2, RSC17, RSA7, RSA15, RTN2d, TO3a]
@@ -67,6 +68,7 @@ Authentication:
           Query the Ably service for the current time instead of relying on a locally-available time of day when issuing a token request.
           Enabled using `queryTime` client option.
 Debugging:
+  .class: Marker
   .synopsis: |
     Behaviours that are not necessarily suitable for production environments,
     however may need to be enabled - even when running against production environments and executing on end-customer/consumer devices - to debug issues.
@@ -83,6 +85,7 @@ Debugging:
       this differently for idiomatic reasons that make sense for the language, framework
       or runtime platform.
 Protocol:
+  .class: Marker
   .synopsis: |
     Relating to the Ably service protocols used by REST and Realtime client instances.
   JSON:
@@ -103,11 +106,13 @@ Realtime:
   .synopsis: |
     Functionality offered by Ably client instances that offer Realtime connectivity.
   Authentication:
+    .class: Marker
     Get Confirmed Client Identifier:
       .specification: [RTC4, RTC17, RSA7a, RSA7b, RSA12, RSA8f, CD2a]
       .synopsis: |
         Get the `clientId` confirmed with the Ably service for this client instance, once a connection has been established.
   Channel:
+    .class: Marker
     Attach:
       .documentation:
         - https://ably.com/docs/realtime/channels#channel-lifecycle
@@ -229,6 +234,7 @@ Realtime:
           The option to specify that attachment to this channel start from a given number of messages or point in time in the past.
           This is done by setting the `rewind` channel parameter using the `setOptions` method on the channel.
   Connection:
+    .class: Marker
     .specification: RTC2
     Disconnected Retry Timeout:
       .specification: [TO3l1, RTN14d]
@@ -316,6 +322,7 @@ REST:
   .synopsis: |
     Functionality offered by Ably client instances that offer support for REST operations.
   Authentication:
+    .class: Marker
     .specification: RSC5
     Authorize:
       .specification: RSA10
@@ -326,6 +333,7 @@ REST:
     Request Token:
       .specification: RSA8e
   Channel:
+    .class: Marker
     .specification: [RSN1, RTC3]
     Encryption:
       .specification: [RSL7, TB2b, RSN3c]
@@ -519,6 +527,7 @@ REST:
       Override the default value of the `httpRequestTimeout` client option,
       the timeout for any single HTTP request and response.
   Service:
+    .class: Marker
     .synopsis: |
       Global operations against the Ably service, not necessarily specific to the Ably application project being used.
     Get Time:
@@ -527,6 +536,7 @@ REST:
         Obtain the Ably service time, to millisecond precision.
         This may be required by clients that do not have access to a sufficiently well maintained time source, to provide timestamps for use in token requests.
   Statistics:
+    .class: Marker
     .documentation: https://ably.com/docs/general/statistics
     .synopsis: |
       Operations relating to Ably application statistics (a.k.a. 'stats').
@@ -543,6 +553,7 @@ REST:
     .synopsis: |
       Receive `ErrorInfo` instances that include an `href` member, populated if provided by the service response, containing an Internet hyperlink for more information on the failure.
 Service:
+  .class: Marker
   .synopsis: |
     Relating to how REST and Realtime client instances communicate with the Ably service,
     in particular relating to resilience, fallbacks, etc..
@@ -596,6 +607,7 @@ Service:
       Override the REST encpoint using `restHost` client option,
       or the Realtime endpoint using the `realtimeHost` client option.
 Testing:
+  .class: Marker
   .synopsis: |
     Behaviours that are not suitable for production environments.
     These options should only be overridden or otherwise utilised when testing against development environments.
@@ -615,6 +627,7 @@ Testing:
       Override the default value of the `tlsPort` client option,
       the TCP port to be used for secure connections using TLS (Transport Layer Security).
 Transport:
+  .class: Marker
   .synopsis: |
     Relating to the network transports used by REST and Realtime client instances,
     specifically features specific to HTTP and TCP.

--- a/sdk.yaml
+++ b/sdk.yaml
@@ -20,7 +20,7 @@ Agent Identifier:
       This does not always include a version (e.g. for `browser` runtime emitted by `ably-js`
       and `xamarin-android`/`xamarin-iOS` runtime emitted by `ably-dotnet`).
 Authentication:
-  .class: Marker
+  .class: Heading
   .documentation:
     - https://ably.com/docs/core-features/authentication
   .specification: [AO1, AO2, RSC17, RSA7, RSA15, RTN2d, TO3a]
@@ -68,7 +68,7 @@ Authentication:
           Query the Ably service for the current time instead of relying on a locally-available time of day when issuing a token request.
           Enabled using `queryTime` client option.
 Debugging:
-  .class: Marker
+  .class: Heading
   .synopsis: |
     Behaviours that are not necessarily suitable for production environments,
     however may need to be enabled - even when running against production environments and executing on end-customer/consumer devices - to debug issues.
@@ -85,7 +85,7 @@ Debugging:
       this differently for idiomatic reasons that make sense for the language, framework
       or runtime platform.
 Protocol:
-  .class: Marker
+  .class: Heading
   .synopsis: |
     Relating to the Ably service protocols used by REST and Realtime client instances.
   JSON:
@@ -106,13 +106,13 @@ Realtime:
   .synopsis: |
     Functionality offered by Ably client instances that offer Realtime connectivity.
   Authentication:
-    .class: Marker
+    .class: Heading
     Get Confirmed Client Identifier:
       .specification: [RTC4, RTC17, RSA7a, RSA7b, RSA12, RSA8f, CD2a]
       .synopsis: |
         Get the `clientId` confirmed with the Ably service for this client instance, once a connection has been established.
   Channel:
-    .class: Marker
+    .class: Heading
     Attach:
       .documentation:
         - https://ably.com/docs/realtime/channels#channel-lifecycle
@@ -234,7 +234,7 @@ Realtime:
           The option to specify that attachment to this channel start from a given number of messages or point in time in the past.
           This is done by setting the `rewind` channel parameter using the `setOptions` method on the channel.
   Connection:
-    .class: Marker
+    .class: Heading
     .specification: RTC2
     Disconnected Retry Timeout:
       .specification: [TO3l1, RTN14d]
@@ -322,7 +322,7 @@ REST:
   .synopsis: |
     Functionality offered by Ably client instances that offer support for REST operations.
   Authentication:
-    .class: Marker
+    .class: Heading
     .specification: RSC5
     Authorize:
       .specification: RSA10
@@ -333,7 +333,7 @@ REST:
     Request Token:
       .specification: RSA8e
   Channel:
-    .class: Marker
+    .class: Heading
     .specification: [RSN1, RTC3]
     Encryption:
       .specification: [RSL7, TB2b, RSN3c]
@@ -527,7 +527,7 @@ REST:
       Override the default value of the `httpRequestTimeout` client option,
       the timeout for any single HTTP request and response.
   Service:
-    .class: Marker
+    .class: Heading
     .synopsis: |
       Global operations against the Ably service, not necessarily specific to the Ably application project being used.
     Get Time:
@@ -536,7 +536,7 @@ REST:
         Obtain the Ably service time, to millisecond precision.
         This may be required by clients that do not have access to a sufficiently well maintained time source, to provide timestamps for use in token requests.
   Statistics:
-    .class: Marker
+    .class: Heading
     .documentation: https://ably.com/docs/general/statistics
     .synopsis: |
       Operations relating to Ably application statistics (a.k.a. 'stats').
@@ -553,7 +553,7 @@ REST:
     .synopsis: |
       Receive `ErrorInfo` instances that include an `href` member, populated if provided by the service response, containing an Internet hyperlink for more information on the failure.
 Service:
-  .class: Marker
+  .class: Heading
   .synopsis: |
     Relating to how REST and Realtime client instances communicate with the Ably service,
     in particular relating to resilience, fallbacks, etc..
@@ -607,7 +607,7 @@ Service:
       Override the REST encpoint using `restHost` client option,
       or the Realtime endpoint using the `realtimeHost` client option.
 Testing:
-  .class: Marker
+  .class: Heading
   .synopsis: |
     Behaviours that are not suitable for production environments.
     These options should only be overridden or otherwise utilised when testing against development environments.
@@ -627,7 +627,7 @@ Testing:
       Override the default value of the `tlsPort` client option,
       the TCP port to be used for secure connections using TLS (Transport Layer Security).
 Transport:
-  .class: Marker
+  .class: Heading
   .synopsis: |
     Relating to the network transports used by REST and Realtime client instances,
     specifically features specific to HTTP and TCP.


### PR DESCRIPTION
This is an idea I came up with when trying to think of ways to make the rendered features matrix easier to visually track when scrolling vertically.

The change presented in this pull request marks a number of the nodes in the canonical feature list tree as "markers", representing the idea that they do not carry direct user-facing value, existing to provide branch points for groups of related features.

Those marker nodes are then formatted differently (row background colour, bold font for the node name, no ticks or crosses per SDK).

Before this change:

<img width="1307" alt="Screenshot 2023-02-03 at 12 08 16" src="https://user-images.githubusercontent.com/8318344/216600288-544b6ce7-300e-4c7f-be1a-3c9379bf2733.png">

After this change:

<img width="1307" alt="Screenshot 2023-02-03 at 12 08 22" src="https://user-images.githubusercontent.com/8318344/216600327-d0548b7a-2d5b-4d53-b3d1-ae731e39fa70.png">
