### PR TITLE
Disallow compliance with Heading feature node only

### DIFF
--- a/build.js
+++ b/build.js
@@ -55,8 +55,15 @@ const parserOptions = {
 const object = YAML.parse(yamlSource, parserOptions);
 const sdkManifests = new Map();
 sdkManifestSources.forEach((sdkManifestSource, sdkManifestSuffix) => {
-  const manifest = new Manifest(YAML.parse(sdkManifestSource, parserOptions), object);
-  sdkManifests.set(sdkManifestSuffix, manifest);
+  try {
+    const manifest = new Manifest(YAML.parse(sdkManifestSource, parserOptions), object);
+    sdkManifests.set(sdkManifestSuffix, manifest);
+  } catch (error) {
+    throw new Error(
+      `Failed manifest parse for ${sdkManifestSuffix}.`,
+      { cause: error },
+    );
+  }
 });
 
 // First Pass: Measure depth.

--- a/manifest.test.js
+++ b/manifest.test.js
@@ -1,9 +1,42 @@
+/* eslint-disable no-new */
 const { Manifest } = require('./manifest');
 
 // Wrap the provide map in a new map, under the compliance key, as required for a manifest.
 const compliance = (map) => new Map([['compliance', map]]);
 
 describe('Manifest', () => {
+  describe('constructor', () => {
+    it('fails when manifest indicates compliance with a header node but not any of its children', () => {
+      const canonicalMap = new Map([
+        ['Root Node with Heading', new Map([
+          ['.class', 'Heading'],
+          ['Child Node 1', null],
+          ['Child Node 2', new Map([
+            ['.class', 'Heading'],
+          ])],
+        ])],
+      ]);
+
+      [
+        new Map([
+          ['Root Node with Heading', null],
+        ]),
+        new Map([
+          ['Root Node with Heading', new Map([['.caveats', 'Some commentary.']])],
+        ]),
+        new Map([
+          ['Root Node with Heading', new Map([
+            ['Child Node 2', null],
+          ])],
+        ]),
+      ].forEach((manifestMap) => {
+        expect(() => {
+          new Manifest(compliance(manifestMap), canonicalMap);
+        }).toThrow(/^Canonical node is a Header at path ".*", yet the manifest node has no children/);
+      });
+    });
+  });
+
   describe('find', () => {
     const emptyMap = new Map();
     const populatedMap = new Map([

--- a/sdk-manifests/ably-ruby.yaml
+++ b/sdk-manifests/ably-ruby.yaml
@@ -20,7 +20,6 @@ compliance:
     Maximum Message Size:
     MessagePack:
   Realtime:
-    Authentication:
     Channel:
       Attach:
 


### PR DESCRIPTION
Fixes a manifest validation oversight introduced in #106 and spotted by @stmoreau when we verbally discussing that change. The Ruby manifest was indicating compliance with `Realtime: Authentication` without further indicating compliance with any of its child nodes. The `Realtime: Authentication` node is now a feature heading, so can only bring value to a manifest if at least one of its children is also included.