### PR TITLE
Extract matrix generation

### DIFF
--- a/core/compare.js
+++ b/core/compare.js
@@ -1,0 +1,18 @@
+/**
+ * Compares two string keys, using our preferred comparison method.
+ *
+ * This method uses `localCompare` with the `sensitivity` option set to 'base',
+ * meaning that comparisons are case insensitive.
+ *
+ * @param {string} a The first string (a.k.a. `referenceStr`).
+ * @param {string} b The second string (a.k.a. `compareString`).
+ * @returns {number} A negative number if `a` occurs before `b`;
+ * positive if the `a` occurs after `b`; 0 if they are equivalent.
+ */
+function compareKeys(a, b) {
+  return a.localeCompare(b, 'en', { sensitivity: 'base' });
+}
+
+module.exports = {
+  compareKeys,
+};

--- a/core/manifest.js
+++ b/core/manifest.js
@@ -22,7 +22,7 @@ class Manifest {
    * Locate a node indicating compliance with a particular feature.
    *
    * @param {string[]} featurePath The feature node names, from root, forming a path to the feature.
-   * @returns {Map|undefined} The feature node, or `undefined` if a node doesn't exist.
+   * @returns {Properties|undefined} The manifest's compliance node properties, or `undefined` if a node doesn't exist.
    */
   find(featurePath) {
     let node = this.manifest.get(COMPLIANCE_KEY);

--- a/core/matrix.js
+++ b/core/matrix.js
@@ -1,0 +1,165 @@
+const { compareKeys } = require('./compare');
+const { Manifest } = require('./manifest');
+const { isPropertyKey, Properties } = require('./sdk-node-properties');
+
+/**
+ * Abstract class (interface) implemented by users of {@link MatrixGenerator#generate}.
+ *
+ * Implementations of this protocol may be supplied in order to receive callbacks while inspecting the canonical feature
+ * list alongside SDK manifests.
+ *
+ * @interface
+ */
+class MatrixConsumer {
+  /**
+   * Called first, upon encountering a feature, before any calls to {@link #onCompliance}.
+   *
+   * @param {string[]} parentKeys The names of the feature nodes forming the hierarchy above this feature node.
+   * @param {string} key The name of this feature node.
+   * @param {Properties} properties Of this feature node.
+   * @param {number} maximumLevel The maximum depth, previously measured or arbitrary.
+   */
+  // eslint-disable-next-line class-methods-use-this, no-unused-vars
+  onFeature(parentKeys, key, properties, maximumLevel) {
+    throw new Error('Not implemented.');
+  }
+
+  /**
+   * Called one or more times, once for each manifest, for each each feature.
+   *
+   * @param {Properties|undefined} compliance Of the manifest's compliance node, or `undefined` if compliance not indicated.
+   * @param {Manifest} manifest From which this compliance was deduced.
+   * @param {Properties} featureProperties Of the feature for which this compliance applies.
+   */
+  // eslint-disable-next-line class-methods-use-this, no-unused-vars
+  onCompliance(compliance, manifest, featureProperties) {
+    throw new Error('Not implemented.');
+  }
+
+  /**
+   * Called last, per feature, once all calls to {@link #onCompliance} have been completed for that feature.
+   */
+  // eslint-disable-next-line class-methods-use-this
+  onFeatureFinished() {
+    throw new Error('Not implemented.');
+  }
+
+  /**
+   * Called when generating if a node was encountered which hasn't been processed. Implementors should log this
+   * information somewhere in case it is needed for debugging purposes.
+   *
+   * @param {number} level The depth within the hierarchy at which this feature node was found.
+   * @param {string} description Of this feature node.
+   */
+  // eslint-disable-next-line class-methods-use-this, no-unused-vars
+  onIgnoredNode(level, description) {
+    throw new Error('Not implemented.');
+  }
+}
+
+/**
+ * A no-op implementation of MatrixConsumer.
+ *
+ * @implements {MatrixConsumer}
+ */
+class VoidConsumer extends MatrixConsumer {
+  // eslint-disable-next-line class-methods-use-this
+  onFeature() { }
+
+  // eslint-disable-next-line class-methods-use-this
+  onCompliance() { }
+
+  // eslint-disable-next-line class-methods-use-this
+  onFeatureFinished() { }
+
+  // eslint-disable-next-line class-methods-use-this
+  onIgnoredNode() { }
+}
+
+class MatrixGenerator {
+  /**
+   * @param {Map} canonicalFeatureList The canonical feature list.
+   * @param {Manifest[]} manifests In the order they're to be explored for each feature.
+   */
+  constructor(canonicalFeatureList, manifests) {
+    this.canonicalFeatureList = canonicalFeatureList;
+    this.manifests = manifests;
+  }
+
+  /**
+   * Inspect the canonical tree from the root node, optionally calling the consumer as that exploration progresses.
+   *
+   * @param {number} maximumDepth The maximum depth, previously measured or arbitrary.
+   * @param {MatrixConsumer} [consumer] To be called during the exploration.
+   * @returns {number} The number of levels found.
+   */
+  generate(maximumDepth, consumer) {
+    return generateMatrix(
+      this.manifests,
+      consumer ?? new VoidConsumer(),
+      maximumDepth,
+      [],
+      this.canonicalFeatureList,
+    );
+  }
+}
+
+/**
+ * Inspect a node, and it's children, optionally rendering to table rows.
+ *
+ * @param {Manifest[]} manifests In the order they're to be explored for each feature.
+ * @param {MatrixConsumer} consumer Call during the generation process.
+ * @param {number} maximumLevel The maximum depth, previously measured or arbitrary.
+ * @param {string[]} parentKeys Parent keys, also indicating the depth of this node. Nodes at root have an empty array.
+ * @param {*} node The canonical feature node.
+ * @returns {number} The number of levels, including this node and its children.
+ */
+function generateMatrix(manifests, consumer, maximumLevel, parentKeys, node) {
+  const level = parentKeys.length;
+  if (level > maximumLevel) {
+    throw new Error(`Maximum depth limit exceeded (${maximumLevel}).`);
+  }
+
+  let maximumDepth = 0;
+  if (node instanceof Map) {
+    const sortedKeys = Array.from(node.keys()).sort(compareKeys);
+    sortedKeys.forEach((key) => {
+      const value = node.get(key);
+      if (!isPropertyKey(key)) {
+        const properties = new Properties(value);
+
+        consumer.onFeature(parentKeys, key, properties, maximumLevel);
+        manifests.forEach((manifest) => {
+          const compliance = manifest.find([...parentKeys, key]);
+          consumer.onCompliance(compliance, manifest, properties);
+        });
+        consumer.onFeatureFinished();
+
+        const depth = generateMatrix(manifests, consumer, maximumLevel, [...parentKeys, key], value);
+        maximumDepth = Math.max(maximumDepth, 1 + depth);
+      }
+    });
+  } else if (Array.isArray(node)) {
+    node.forEach((element) => {
+      const depth = generateMatrix(manifests, consumer, maximumLevel, parentKeys, element);
+      maximumDepth = Math.max(maximumDepth, depth);
+    });
+  } else if (node instanceof String || typeof node === 'string') {
+    if (consumer) {
+      consumer.onIgnoredNode(level, `${node}`);
+    }
+    maximumDepth = 1;
+  } else if (node === null) {
+    // the value for a key with no value defined
+  } else if (consumer) {
+    // informational only, while debugging
+    consumer.onIgnoredNode(level, `${typeof node} = ${node}`);
+  }
+
+  return maximumDepth;
+}
+
+module.exports = {
+  MatrixGenerator,
+  MatrixConsumer,
+};

--- a/render/build.js
+++ b/render/build.js
@@ -4,11 +4,9 @@ const { marked } = require('marked');
 const path = require('path');
 const YAML = require('yaml');
 
-const {
-  isPropertyKey,
-  Properties,
-} = require('@ably/features-core/sdk-node-properties');
+const { compareKeys } = require('@ably/features-core/compare');
 const { Manifest } = require('@ably/features-core/manifest');
+const { MatrixGenerator, MatrixConsumer } = require('@ably/features-core/matrix');
 
 const {
   DocumentWriter,
@@ -21,6 +19,8 @@ const svgSize = '1.5em';
 const crossSvg = `<svg xmlns="http://www.w3.org/2000/svg" height="${svgSize}" width="${svgSize}" viewBox="0 0 48 48"><path d="M12.45 37.65 10.35 35.55 21.9 24 10.35 12.45 12.45 10.35 24 21.9 35.55 10.35 37.65 12.45 26.1 24 37.65 35.55 35.55 37.65 24 26.1Z"/></svg>`;
 const tickSvg = `<svg xmlns="http://www.w3.org/2000/svg" height="${svgSize}" width="${svgSize}" viewBox="0 0 48 48"><path d="M18.9 35.7 7.7 24.5 9.85 22.35 18.9 31.4 38.1 12.2 40.25 14.35Z"/></svg>`;
 const partialSvg = `<svg xmlns="http://www.w3.org/2000/svg" height="${svgSize}" width="${svgSize}" viewBox="0 0 48 48"><path d="M10.4 26.4Q9.4 26.4 8.7 25.7Q8 25 8 24Q8 23 8.7 22.3Q9.4 21.6 10.4 21.6Q11.4 21.6 12.1 22.3Q12.8 23 12.8 24Q12.8 25 12.1 25.7Q11.4 26.4 10.4 26.4ZM24 26.4Q23 26.4 22.3 25.7Q21.6 25 21.6 24Q21.6 23 22.3 22.3Q23 21.6 24 21.6Q25 21.6 25.7 22.3Q26.4 23 26.4 24Q26.4 25 25.7 25.7Q25 26.4 24 26.4ZM37.6 26.4Q36.6 26.4 35.9 25.7Q35.2 25 35.2 24Q35.2 23 35.9 22.3Q36.6 21.6 37.6 21.6Q38.6 21.6 39.3 22.3Q40 23 40 24Q40 25 39.3 25.7Q38.6 26.4 37.6 26.4Z"/></svg>`;
+
+const verticalBordersStyle = 'border-slate-300 border-b-2';
 
 const sdkManifestSuffixes = [
   'java',
@@ -68,9 +68,12 @@ sdkManifestSources.forEach((sdkManifestSource, sdkManifestSuffix) => {
   }
 });
 
+const sortedManifests = sdkManifestSuffixes.map((suffix) => sdkManifests.get(suffix));
+const generator = new MatrixGenerator(object, sortedManifests);
+
 // First Pass: Measure depth.
 const arbitraryMaximumDepth = 10;
-const levelCount = generateTableRows(null, arbitraryMaximumDepth, [], object);
+const levelCount = generator.generate(arbitraryMaximumDepth);
 console.log(`levelCount = ${levelCount}`);
 
 // Create output directory in standard location within working directory.
@@ -85,6 +88,144 @@ const documentWriter = new DocumentWriter(
   fs.createWriteStream(path.join(outputDirectoryPath, 'index.html')),
 );
 
+const commonFeatureCellStyle = `${verticalBordersStyle} border-r-2`;
+
+/**
+ * @implements {MatrixConsumer}
+ */
+class TableRenderer extends MatrixConsumer {
+  constructor(tableWriter) {
+    super();
+    this.tableWriter = tableWriter;
+  }
+
+  onFeature(parentKeys, key, properties, maximumLevel) {
+    const {
+      specificationPoints,
+      documentationUrls,
+      requires,
+      synopsis,
+      isHeading,
+    } = properties;
+    const level = parentKeys.length;
+
+    const { tableWriter } = this;
+    tableWriter.class(`align-middle tooltip-container${isHeading ? ' bg-slate-200' : ''}`);
+    const rowWriter = tableWriter.startRow();
+    this.rowWriter = rowWriter; // used by calls to onCompliance() for this feature row
+
+    // Indent using empty cells
+    for (let i = 1; i <= level; i += 1) {
+      rowWriter.class(`px-3 ${verticalBordersStyle}`);
+      rowWriter.cell((cellContentWriter) => {
+        cellContentWriter.write('&nbsp;');
+      });
+    }
+
+    // Contents, with column spanning to fill remaining cells, after indentation
+    const cellCount = maximumLevel - level;
+    if (cellCount > 1) {
+      rowWriter.columnSpan(cellCount);
+    }
+    rowWriter.class(`pr-3 whitespace-nowrap ${commonFeatureCellStyle} ${isHeading ? 'font-bold' : ''}`);
+    rowWriter.cell((cellContentWriter) => {
+      if (level > 0) {
+        const tip = `<strong>${escape(parentKeys.join(': '))}</strong>: ${escape(key)}`;
+        cellContentWriter.write(`<span class="tooltip-contents">${tip}</span>`);
+      }
+      cellContentWriter.text(key);
+    });
+
+    // Specification Points
+    rowWriter.class(`px-1 ${commonFeatureCellStyle}`);
+    rowWriter.cell((cellContentWriter) => {
+      cellContentWriter.write(specificationPoints
+        ? specificationPoints
+          .map((element) => element.toHtmlLink())
+          .join(', ')
+        : '&nbsp;');
+    });
+
+    // Conceptual Documentation Links and Synopsis
+    rowWriter.class(`px-1 ${commonFeatureCellStyle}`);
+    rowWriter.cell((cellContentWriter) => {
+      let empty = true;
+
+      const markdownRequires = requires
+        ? `Requires: ${requires.map((featureNodePath) => `**${featureNodePath.join(': ')}**`).join(' | ')}`
+        : null;
+      const markdown = synopsis
+        ? `${synopsis}${markdownRequires ? `\n${markdownRequires}` : ''}`
+        : markdownRequires;
+
+      if (documentationUrls) {
+        const needComplexLayout = !!markdown;
+
+        if (needComplexLayout) {
+          // With Synopsis and Documentation URLs we need a more complex layout
+          cellContentWriter.write('<div class="flex flex-row">'); // this div is closed below, after writing documentation URLs
+          cellContentWriter.write(`<div class="grow">${marked.parse(markdown)}</div>`);
+          cellContentWriter.write('<div class="grow-0">'); // this div is closed below, after writing documentation URLs
+        }
+
+        cellContentWriter.write(documentationUrls
+          .map((element) => `<a class="btn btn-blue" href="${element}" target="_blank" rel="noopener">${titleForLink(element)}</a>`)
+          .join(' '));
+
+        if (needComplexLayout) {
+          cellContentWriter.write('</div></div>');
+        }
+
+        empty = false;
+      } else if (markdown) {
+        // No Documentation URLs, so simply render the Synopsis.
+        cellContentWriter.write(marked.parse(markdown));
+        empty = false;
+      }
+      if (empty) {
+        cellContentWriter.write('&nbsp;');
+      }
+    });
+  }
+
+  onCompliance(compliance, manifest, featureProperties) {
+    const { rowWriter } = this;
+    const { isHeading } = featureProperties;
+
+    let colourClass = 'bg-red-400';
+    let svg = crossSvg;
+    if (compliance) {
+      const { caveats, variants } = compliance;
+      const hasPartialSupportForVariants = variants && manifest.isPartialVariantsCoverage(variants);
+      if (hasPartialSupportForVariants || caveats) {
+        colourClass = 'bg-amber-400';
+        svg = partialSvg;
+      } else {
+        colourClass = 'bg-green-400';
+        svg = tickSvg;
+      }
+    }
+
+    rowWriter.class(`px-1 ${isHeading ? '' : colourClass} ${commonFeatureCellStyle}`);
+    rowWriter.cell((cellContentWriter) => {
+      cellContentWriter.write('<div class="flex justify-center">');
+      cellContentWriter.write(isHeading ? '&nbsp;' : svg);
+      cellContentWriter.write('</div>');
+    });
+  }
+
+  onFeatureFinished() {
+    this.tableWriter.finishRow();
+    this.rowWriter = undefined;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  onIgnoredNode(level, description) {
+    const consoleIndent = ' '.repeat(2).repeat(level);
+    console.log(`${consoleIndent}"${description}"`);
+  }
+}
+
 documentWriter.document((contentWriter) => {
   contentWriter.h(1, `${title} ${subTitle}`);
 
@@ -96,7 +237,7 @@ documentWriter.document((contentWriter) => {
     renderTableHeaderRow(tableWriter, levelCount);
 
     // Second Pass: Render rows.
-    generateTableRows(tableWriter, levelCount, [], object);
+    generator.generate(levelCount, new TableRenderer(tableWriter));
   });
 });
 
@@ -139,168 +280,6 @@ function renderTableHeaderRow(writer, maximumLevel) {
       });
     });
   });
-}
-
-/**
- * Inspect a node, and it's children, optionally rendering to table rows.
- *
- * @param {TableWriter} [writer] The HTML table writer to use, or `null` to use this function purely to measure depth.
- * @param {number} maximumLevel The maximum depth, previously measured or arbitrary.
- * @param {string[]} parentKeys Parent keys, also indicating the depth of this node. Nodes at root have an empty array.
- * @param {*} node The node.
- * @returns {number} The number of levels, including this node and its children.
- */
-function generateTableRows(writer, maximumLevel, parentKeys, node) {
-  const level = parentKeys.length;
-  if (level > maximumLevel) {
-    throw new Error(`Maximum depth limit exceeded (${maximumLevel}).`);
-  }
-
-  const consoleIndent = ' '.repeat(2).repeat(level);
-  let maximumDepth = 0;
-  if (node instanceof Map) {
-    const sortedKeys = Array.from(node.keys()).sort(compareKeys);
-    sortedKeys.forEach((key) => {
-      const value = node.get(key);
-      if (!isPropertyKey(key)) {
-        if (writer) {
-          const {
-            specificationPoints,
-            documentationUrls,
-            requires,
-            synopsis,
-            isHeading,
-          } = new Properties(value);
-
-          console.log(`${consoleIndent}${key}:`);
-          const verticalBordersStyle = 'border-slate-300 border-b-2';
-          const commonCellStyle = `${verticalBordersStyle} border-r-2`;
-          writer.class(`align-middle tooltip-container${isHeading ? ' bg-slate-200' : ''}`);
-          writer.row((rowWriter) => {
-            // Indent using empty cells
-            for (let i = 1; i <= level; i += 1) {
-              rowWriter.class(`px-3 ${verticalBordersStyle}`);
-              rowWriter.cell((cellContentWriter) => {
-                cellContentWriter.write('&nbsp;');
-              });
-            }
-
-            // Contents, with column spanning to fill remaining cells, after indentation
-            const cellCount = maximumLevel - level;
-            if (cellCount > 1) {
-              rowWriter.columnSpan(cellCount);
-            }
-            rowWriter.class(`pr-3 whitespace-nowrap ${commonCellStyle} ${isHeading ? 'font-bold' : ''}`);
-            rowWriter.cell((cellContentWriter) => {
-              if (level > 0) {
-                const tip = `<strong>${escape(parentKeys.join(': '))}</strong>: ${escape(key)}`;
-                cellContentWriter.write(`<span class="tooltip-contents">${tip}</span>`);
-              }
-              cellContentWriter.text(key);
-            });
-
-            // Specification Points
-            rowWriter.class(`px-1 ${commonCellStyle}`);
-            rowWriter.cell((cellContentWriter) => {
-              cellContentWriter.write(specificationPoints
-                ? specificationPoints
-                  .map((element) => element.toHtmlLink())
-                  .join(', ')
-                : '&nbsp;');
-            });
-
-            // Conceptual Documentation Links and Synopsis
-            rowWriter.class(`px-1 ${commonCellStyle}`);
-            rowWriter.cell((cellContentWriter) => {
-              let empty = true;
-
-              const markdownRequires = requires
-                ? `Requires: ${requires.map((featureNodePath) => `**${featureNodePath.join(': ')}**`).join(' | ')}`
-                : null;
-              const markdown = synopsis
-                ? `${synopsis}${markdownRequires ? `\n${markdownRequires}` : ''}`
-                : markdownRequires;
-
-              if (documentationUrls) {
-                const needComplexLayout = !!markdown;
-
-                if (needComplexLayout) {
-                  // With Synopsis and Documentation URLs we need a more complex layout
-                  cellContentWriter.write('<div class="flex flex-row">'); // this div is closed below, after writing documentation URLs
-                  cellContentWriter.write(`<div class="grow">${marked.parse(markdown)}</div>`);
-                  cellContentWriter.write('<div class="grow-0">'); // this div is closed below, after writing documentation URLs
-                }
-
-                cellContentWriter.write(documentationUrls
-                  .map((element) => `<a class="btn btn-blue" href="${element}" target="_blank" rel="noopener">${titleForLink(element)}</a>`)
-                  .join(' '));
-
-                if (needComplexLayout) {
-                  cellContentWriter.write('</div></div>');
-                }
-
-                empty = false;
-              } else if (markdown) {
-                // No Documentation URLs, so simply render the Synopsis.
-                cellContentWriter.write(marked.parse(markdown));
-                empty = false;
-              }
-              if (empty) {
-                cellContentWriter.write('&nbsp;');
-              }
-            });
-
-            // SDK columns
-            sdkManifestSuffixes.forEach((sdkManifestSuffix) => {
-              const manifest = sdkManifests.get(sdkManifestSuffix);
-              const compliance = manifest.find([...parentKeys, key]);
-
-              let colourClass = 'bg-red-400';
-              let svg = crossSvg;
-              if (compliance) {
-                const { caveats, variants } = compliance;
-                const hasPartialSupportForVariants = variants && manifest.isPartialVariantsCoverage(variants);
-                if (hasPartialSupportForVariants || caveats) {
-                  colourClass = 'bg-amber-400';
-                  svg = partialSvg;
-                } else {
-                  colourClass = 'bg-green-400';
-                  svg = tickSvg;
-                }
-              }
-
-              rowWriter.class(`px-1 ${isHeading ? '' : colourClass} ${commonCellStyle}`);
-              rowWriter.cell((cellContentWriter) => {
-                cellContentWriter.write('<div class="flex justify-center">');
-                cellContentWriter.write(isHeading ? '&nbsp;' : svg);
-                cellContentWriter.write('</div>');
-              });
-            });
-          });
-        }
-
-        const depth = generateTableRows(writer, maximumLevel, [...parentKeys, key], value);
-        maximumDepth = Math.max(maximumDepth, 1 + depth);
-      }
-    });
-  } else if (Array.isArray(node)) {
-    node.forEach((element) => {
-      const depth = generateTableRows(writer, maximumLevel, parentKeys, element);
-      maximumDepth = Math.max(maximumDepth, depth);
-    });
-  } else if (node instanceof String || typeof node === 'string') {
-    if (writer) {
-      console.log(`${consoleIndent}"${node}"`);
-    }
-    maximumDepth = 1;
-  } else if (node === null) {
-    // the value for a key with no value defined
-  } else if (writer) {
-    // informational only, while debugging
-    console.log(`${consoleIndent}${typeof node} = ${node}`);
-  }
-
-  return maximumDepth;
 }
 
 /**
@@ -392,21 +371,6 @@ function validateMapItems(items, parentKeys) {
       validateStructure(value, [...parentKeys, key]);
     }
   });
-}
-
-/**
- * Compares two string keys, using our preferred comparison method.
- *
- * This method uses `localCompare` with the `sensitivity` option set to 'base',
- * meaning that comparisons are case insensitive.
- *
- * @param {string} a The first string (a.k.a. `referenceStr`).
- * @param {string} b The second string (a.k.a. `compareString`).
- * @returns {number} A negative number if `a` occurs before `b`;
- * positive if the `a` occurs after `b`; 0 if they are equivalent.
- */
-function compareKeys(a, b) {
-  return a.localeCompare(b, 'en', { sensitivity: 'base' });
 }
 
 /**

--- a/render/html.js
+++ b/render/html.js
@@ -145,10 +145,36 @@ class TableWriter extends Writer {
    * @param {TableRowGenerator} generator Code to populate the table row. Called synchronously.
    */
   row(generator) {
+    generator(this.startRow());
+    this.finishRow();
+  }
+
+  /**
+   * Create a table row. The finishRow() method must be called after the row has been populated using the returned writer.
+   *
+   * @returns {TableRowWriter} The writer to be used to populate content for this row.
+   */
+  startRow() {
+    if (this.inTableRow) {
+      throw new Error('Already within startRow() for this TableWriter.');
+    }
+
     const attributes = this.useAttributes();
     this.write(`<tr ${attributes.join(' ')}>`);
-    generator(new TableRowWriter(this.writeStream));
+    this.inTableRow = true;
+    return new TableRowWriter(this.writeStream);
+  }
+
+  /**
+   * Finish a table row. This method must be called after a matching call to startRow().
+   */
+  finishRow() {
+    if (!this.inTableRow) {
+      throw new Error('Not seen startRow() for this TableWriter.');
+    }
+
     this.write('</tr>');
+    this.inTableRow = false;
   }
 }
 


### PR DESCRIPTION
The HTML rendering was very much inter-mingled with the core business logic of matrix generation (canonical features list exploration and compliance checks against SDK manifests).

This pull request addresses that and should make this area of the codebase easier to unit test.

I considered adding some tests for this new `MatrixGenerator` class (essentially, checking the code paths within the file-internal `generateMatrix` function), however I decided that the complexity/time involved to make those outweighed the benefit to the codebase as these parts were already well proven in the original location.